### PR TITLE
pyjarray memory leak fixes

### DIFF
--- a/src/jep/pyembed.c
+++ b/src/jep/pyembed.c
@@ -1146,9 +1146,6 @@ void pyembed_setloader(JNIEnv *env, intptr_t _jepThread, jobject cl) {
 // convert pyobject to boxed java value
 jobject pyembed_box_py(JNIEnv *env, PyObject *result) {
 
-    if(result == Py_None)
-        return NULL;
-
     // class and object need to return a new local ref so the object
     // isn't garbage collected.
 

--- a/src/jep/pyjarray.c
+++ b/src/jep/pyjarray.c
@@ -546,8 +546,8 @@ static void pyjarray_dealloc(PyJarray_Object *self) {
         // can't guarantee mode 0 will work in this case...
         pyjarray_release_pinned(self, JNI_ABORT);
 
-        // some environments will leak memory if self->object is deleted
-        // before pyjarray_release_pinned
+        // pyjarray_release_pinned potentially uses self->object so we can
+        // only delete self->object afterwards
         if(self->object)
             (*env)->DeleteGlobalRef(env, self->object);
     } // if env


### PR DESCRIPTION
I messed up the first commit but it doesn't seem possible to roll back once it's pushed into the repo.  So just by undoing the changes and putting the undo on the next commit, it appears that you won't pull in the messed up changes?

Our system is heavy on numpy usage and therefore light on the pyjarray usage, so it's possible I am misunderstanding pyjarray_release_pinned and you don't want that change.  I can't remember why I put that in.

I also don't remember how I determined pyjarrayiter_next was leaking, but a simple test of infinitely looping over the pyjarray, over and over again, will probably show the memory climbing.
