### PR TITLE
Make ClassList::loadClassPath inspect manifest classpath

### DIFF
--- a/src/jep/ClassList.java
+++ b/src/jep/ClassList.java
@@ -104,7 +104,7 @@ public class ClassList implements ClassEnquirer {
                         String[] relativePaths = classpath.split(" ");
 
                         for(String relativePath : relativePaths) {
-                            queue.add(String.join(File.separator, file.getParent(), relativePath));
+							queue.add(file.getParent() + File.separator + relativePath);
                         }
                     }
                 }

--- a/src/jep/ClassList.java
+++ b/src/jep/ClassList.java
@@ -30,14 +30,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
+import java.util.*;
+import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 /**
  * A singleton that searches for loaded classes from the JRE and the Java
@@ -77,8 +74,14 @@ public class ClassList implements ClassEnquirer {
                 System.getProperty("java.class.path"),
                 System.getProperty("path.separator"));
 
-        while (tok.hasMoreTokens()) {
-            String el = tok.nextToken();
+        Queue<String> queue = new LinkedList<>();
+
+        while(tok.hasMoreTokens()) {
+            queue.add(tok.nextToken());
+        }
+
+        while (!queue.isEmpty()) {
+            String el = queue.remove();
 
             if (!el.toLowerCase().endsWith(".jar")) {
                 // ignore filesystem classpath
@@ -91,6 +94,21 @@ public class ClassList implements ClassEnquirer {
                 continue;
 
             try (JarFile jfile = new JarFile(el, false)) {
+
+                // add entries from manifest to check later
+                Manifest manifest = jfile.getManifest();
+                if (manifest != null) {
+                    String classpath = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
+
+                    if(classpath != null) {
+                        String[] relativePaths = classpath.split(" ");
+
+                        for(String relativePath : relativePaths) {
+                            queue.add(String.join(File.separator, file.getParent(), relativePath));
+                        }
+                    }
+                }
+
                 Enumeration<JarEntry> entries = jfile.entries();
                 while (entries.hasMoreElements()) {
                     String entry = entries.nextElement().getName();


### PR DESCRIPTION
`ClassList::loadClassPath` currently ignores all non `.class` files inside `.jar` files. This means that any dependencies in the manifest do not get loaded which can lead to import errors. This PR fixes that.
