### PR TITLE
Make ClassList::loadClassPath inspect manifest classpath

### DIFF
--- a/src/main/java/jep/ClassList.java
+++ b/src/main/java/jep/ClassList.java
@@ -78,12 +78,13 @@ public class ClassList implements ClassEnquirer {
         Set<String> seen = new HashSet<>();
 
         while(tok.hasMoreTokens()) {
-            queue.add(tok.nextToken());
+            String el = tok.nextToken();
+            queue.add(el);
+            seen.add(el);
         }
 
         while (!queue.isEmpty()) {
             String el = queue.remove();
-            seen.add(el);
 
             if (!el.toLowerCase().endsWith(".jar")) {
                 // ignore filesystem classpath
@@ -109,6 +110,7 @@ public class ClassList implements ClassEnquirer {
                             String path = file.getParent() + File.separator + relativePath;
                             if(!seen.contains(path)) {
                                 queue.add(path);
+                                seen.add(path);
                             }
                         }
                     }


### PR DESCRIPTION
`ClassList::loadClassPath` currently ignores all non `.class` files inside `.jar` files. This means that any dependencies in the manifest do not get loaded which can lead to import errors. This PR fixes that.
