### PR TITLE
Always return a `PyObject` if requested type is `PyObject`.

### DIFF
--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -865,6 +865,16 @@ jobject PyObject_As_jobject(JNIEnv *env, PyObject *pyobject,
         if ((*env)->IsAssignableFrom(env, pyjobject->clazz, expectedType)) {
             return (*env)->NewLocalRef(env, pyjobject->object);
         }
+    } else if (PyCallable_Check(pyobject)) {
+        if (isFunctionalInterfaceType(env, expectedType)) {
+            return PyCallable_as_functional_interface(env, pyobject, expectedType);
+        } else if (PyErr_Occurred()) {
+            return NULL;
+        } else if ((*env)->IsAssignableFrom(env, JPYCALLABLE_TYPE, expectedType)) {
+            return PyCallable_As_JPyCallable(env, pyobject);
+        }
+    } else if ((*env)->IsAssignableFrom(env, expectedType, JPYOBJECT_TYPE)) {
+        return PyObject_As_JPyObject(env, pyobject);
 #if PY_MAJOR_VERSION < 3
     } else if (PyString_Check(pyobject)) {
         return pystring_as_jobject(env, pyobject, expectedType);
@@ -900,14 +910,6 @@ jobject PyObject_As_jobject(JNIEnv *env, PyObject *pyobject,
         return pyfastsequence_as_jobject(env, pyobject, expectedType);
     } else if (PyDict_Check(pyobject)) {
         return pydict_as_jobject(env, pyobject, expectedType);
-    } else if (PyCallable_Check(pyobject)) {
-        if (isFunctionalInterfaceType(env, expectedType)) {
-            return PyCallable_as_functional_interface(env, pyobject, expectedType);
-        } else if (PyErr_Occurred()) {
-            return NULL;
-        } else if ((*env)->IsAssignableFrom(env, JPYCALLABLE_TYPE, expectedType)) {
-            return PyCallable_As_JPyCallable(env, pyobject);
-        }
 #if JEP_NUMPY_ENABLED
     } else if (npy_array_check(pyobject)) {
         return convert_pyndarray_jobject(env, pyobject, expectedType);

--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -865,15 +865,7 @@ jobject PyObject_As_jobject(JNIEnv *env, PyObject *pyobject,
         if ((*env)->IsAssignableFrom(env, pyjobject->clazz, expectedType)) {
             return (*env)->NewLocalRef(env, pyjobject->object);
         }
-    } else if (PyCallable_Check(pyobject)) {
-        if (isFunctionalInterfaceType(env, expectedType)) {
-            return PyCallable_as_functional_interface(env, pyobject, expectedType);
-        } else if (PyErr_Occurred()) {
-            return NULL;
-        } else if ((*env)->IsAssignableFrom(env, JPYCALLABLE_TYPE, expectedType)) {
-            return PyCallable_As_JPyCallable(env, pyobject);
-        }
-    } else if ((*env)->IsAssignableFrom(env, expectedType, JPYOBJECT_TYPE)) {
+    } else if ((*env)->IsSameObject(env, expectedType, JPYOBJECT_TYPE)) {
         return PyObject_As_JPyObject(env, pyobject);
 #if PY_MAJOR_VERSION < 3
     } else if (PyString_Check(pyobject)) {
@@ -910,6 +902,14 @@ jobject PyObject_As_jobject(JNIEnv *env, PyObject *pyobject,
         return pyfastsequence_as_jobject(env, pyobject, expectedType);
     } else if (PyDict_Check(pyobject)) {
         return pydict_as_jobject(env, pyobject, expectedType);
+    } else if (PyCallable_Check(pyobject)) {
+        if (isFunctionalInterfaceType(env, expectedType)) {
+            return PyCallable_as_functional_interface(env, pyobject, expectedType);
+        } else if (PyErr_Occurred()) {
+            return NULL;
+        } else if ((*env)->IsAssignableFrom(env, JPYCALLABLE_TYPE, expectedType)) {
+            return PyCallable_As_JPyCallable(env, pyobject);
+        }
 #if JEP_NUMPY_ENABLED
     } else if (npy_array_check(pyobject)) {
         return convert_pyndarray_jobject(env, pyobject, expectedType);

--- a/src/test/java/jep/test/numpy/TestNumpy.java
+++ b/src/test/java/jep/test/numpy/TestNumpy.java
@@ -7,6 +7,7 @@ import jep.Jep;
 import jep.JepConfig;
 import jep.JepException;
 import jep.NDArray;
+import jep.python.PyObject;
 
 /**
  * Runs a variety of simple tests to verify numpy interactions are working
@@ -28,6 +29,7 @@ public class TestNumpy {
      */
     public void testSetAndGet(Jep jep) throws JepException {
         int[] dimensions = new int[] { 4 };
+	PyObject asPyObj;
 
         // test boolean[]
         NDArray<boolean[]> zarray = new NDArray<>(
@@ -46,6 +48,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "boolean[].hashCode() before != boolean[].hasCode() after");
         }
+	asPyObj = jep.getValue("zarray", PyObject.class);
 
         // test byte[]
         NDArray<byte[]> barray = new NDArray<>(
@@ -64,6 +67,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "byte[].hashCode() before != byte[].hasCode() after");
         }
+	asPyObj = jep.getValue("barray", PyObject.class);
 
         // test short[]
         NDArray<short[]> sarray = new NDArray<>(new short[] { 5, 3, 1, 8 },
@@ -82,6 +86,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "short[].hashCode() before != short[].hasCode() after");
         }
+	asPyObj = jep.getValue("sarray", PyObject.class);
 
         // test int[]
         NDArray<int[]> iarray = new NDArray<>(new int[] { 547, 232, -675, 101 },
@@ -100,6 +105,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "int[].hashCode() before != int[].hasCode() after");
         }
+	asPyObj = jep.getValue("iarray", PyObject.class);
 
         // test long[]
         NDArray<long[]> larray = new NDArray<>(
@@ -119,6 +125,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "long[].hashCode() before != long[].hasCode() after");
         }
+	asPyObj = jep.getValue("larray", PyObject.class);
 
         // test float[]
         NDArray<float[]> farray = new NDArray<>(
@@ -137,6 +144,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "float[].hashCode() before != float[].hasCode() after");
         }
+	asPyObj = jep.getValue("farray", PyObject.class);
 
         // test double[]
         NDArray<double[]> darray = new NDArray<>(
@@ -156,6 +164,7 @@ public class TestNumpy {
             throw new AssertionError(
                     "double[].hashCode() before != double[].hasCode() after");
         }
+	asPyObj = jep.getValue("darray", PyObject.class);
 
         // System.out.println("NDArray get/set checked out OK");
     }


### PR DESCRIPTION
Adds a higher-priority check if the requested type is `PyObject`. If it is, a `PyObject` will be returned.

Fixes an issue with numpy arrays – currently, they cannot be retrieved as a `PyObject`, and attempting to do so results in a `TypeError` (since numpy conversion logic has no escape hatch if expected type is not a Java array nor Java `NDArray`).

I did this because I think it should always be possible to ask for (and get) a `PyObject`. For example, I may want to operate on large numpy arrays (or other large data structures) that were created from Python without copying to the JVM.