### PR TITLE
Add `callAs` overloads to `PyCallable`

### DIFF
--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -61,7 +61,10 @@ void pyembed_close(void);
 void pyembed_run(JNIEnv*, intptr_t, char*);
 jobject pyembed_invoke_method(JNIEnv*, intptr_t, const char*, jobjectArray,
                               jobject);
+jobject pyembed_invoke_method_as(JNIEnv*, intptr_t, const char*, jobjectArray,
+                              jobject, jclass);
 jobject pyembed_invoke(JNIEnv*, PyObject*, jobjectArray, jobject);
+jobject pyembed_invoke_as(JNIEnv*, PyObject*, jobjectArray, jobject, jclass);
 void pyembed_eval(JNIEnv*, intptr_t, char*);
 int pyembed_compile_string(JNIEnv*, intptr_t, char*);
 void pyembed_setloader(JNIEnv*, intptr_t, jobject);

--- a/src/main/c/Jep/python/jpycallable.c
+++ b/src/main/c/Jep/python/jpycallable.c
@@ -36,7 +36,7 @@
  */
 JNIEXPORT jobject JNICALL Java_jep_python_PyCallable_call
 (JNIEnv *env, jobject this, jlong tstate, jlong pyobj, jobjectArray args,
- jobject kwargs)
+ jobject kwargs, jclass expectedType)
 {
 
     JepThread  *jepThread;
@@ -51,7 +51,7 @@ JNIEXPORT jobject JNICALL Java_jep_python_PyCallable_call
 
     pyObject = (PyObject*) pyobj;
     PyEval_AcquireThread(jepThread->tstate);
-    ret = pyembed_invoke(env, pyObject, args, kwargs);
+    ret = pyembed_invoke_as(env, pyObject, args, kwargs, expectedType);
     PyEval_ReleaseThread(jepThread->tstate);
     return ret;
 }

--- a/src/main/java/jep/python/PyCallable.java
+++ b/src/main/java/jep/python/PyCallable.java
@@ -77,8 +77,23 @@ public class PyCallable extends PyObject {
      *             if an error occurs
      */
     public Object call(Object... args) throws JepException {
+        return callAs(Object.class, args);
+    }
+
+    /**
+     * Invokes this callable with the args in order, converting the return value to the given class.
+     *
+     * @param expectedType
+     *            The expected return type of the invocation
+     * @param args
+     *            args to pass to the function in order
+     * @return an value of the given type
+     * @throws JepException
+     *             if an error occurs
+     */
+    public <T> T callAs(Class<T> expectedType, Object... args) throws JepException {
         checkValid();
-        return call(pointer.tstate, pointer.pyObject, args, null);
+        return expectedType.cast(call(pointer.tstate, pointer.pyObject, args, null, expectedType));
     }
 
     /**
@@ -91,8 +106,23 @@ public class PyCallable extends PyObject {
      *             if an error occurs
      */
     public Object call(Map<String, Object> kwargs) throws JepException {
+        return callAs(Object.class, kwargs);
+    }
+
+    /**
+     * Invokes this callable with keyword args.
+     * 
+     * @param expectedType
+     *            The expected return type of the invocation
+     * @param kwargs
+     *            a Map of keyword args
+     * @return an {@link Object} value
+     * @throws JepException
+     *             if an error occurs
+     */
+    public <T> T callAs(Class<T> expectedType, Map<String, Object> kwargs) throws JepException {
         checkValid();
-        return call(pointer.tstate, pointer.pyObject, null, kwargs);
+        return expectedType.cast(call(pointer.tstate, pointer.pyObject, null, kwargs, expectedType));
     }
 
     /**
@@ -108,11 +138,29 @@ public class PyCallable extends PyObject {
      */
     public Object call(Object[] args, Map<String, Object> kwargs)
             throws JepException {
+        return callAs(Object.class, args, kwargs);
+    }
+
+        /**
+     * Invokes this callable with positional args and keyword args.
+     * 
+     * @param expectedType
+     *            The expected return type of the invocation
+     * @param args
+     *            args to pass to the function in order
+     * @param kwargs
+     *            a Map of keyword args
+     * @return an {@link Object} value
+     * @throws JepException
+     *             if an error occurs
+     */
+    public <T> T callAs(Class<T> expectedType, Object[] args, Map<String, Object> kwargs)
+            throws JepException {
         checkValid();
-        return call(pointer.tstate, pointer.pyObject, args, kwargs);
+        return expectedType.cast(call(pointer.tstate, pointer.pyObject, args, kwargs, expectedType));
     }
 
     private native Object call(long tstate, long pyObject, Object[] args,
-            Map<String, Object> kwargs) throws JepException;
+            Map<String, Object> kwargs, Class expectedType) throws JepException;
 
 }

--- a/src/main/java/jep/python/PyCallable.java
+++ b/src/main/java/jep/python/PyCallable.java
@@ -87,7 +87,7 @@ public class PyCallable extends PyObject {
      *            The expected return type of the invocation
      * @param args
      *            args to pass to the function in order
-     * @return an value of the given type
+     * @return a value of the given type
      * @throws JepException
      *             if an error occurs
      */
@@ -110,13 +110,13 @@ public class PyCallable extends PyObject {
     }
 
     /**
-     * Invokes this callable with keyword args.
+     * Invokes this callable with keyword args, converting the return value to the given class.
      * 
      * @param expectedType
      *            The expected return type of the invocation
      * @param kwargs
      *            a Map of keyword args
-     * @return an {@link Object} value
+     * @return a value of the given type
      * @throws JepException
      *             if an error occurs
      */
@@ -141,8 +141,8 @@ public class PyCallable extends PyObject {
         return callAs(Object.class, args, kwargs);
     }
 
-        /**
-     * Invokes this callable with positional args and keyword args.
+    /**
+     * Invokes this callable with positional args and keyword args, converting the return value to the given class.
      * 
      * @param expectedType
      *            The expected return type of the invocation
@@ -150,7 +150,7 @@ public class PyCallable extends PyObject {
      *            args to pass to the function in order
      * @param kwargs
      *            a Map of keyword args
-     * @return an {@link Object} value
+     * @return a value of the given type
      * @throws JepException
      *             if an error occurs
      */

--- a/src/test/java/jep/test/TestGetJPyObject.java
+++ b/src/test/java/jep/test/TestGetJPyObject.java
@@ -135,10 +135,23 @@ public class TestGetJPyObject {
             throw new IllegalStateException(
                     "JPyCallable chr does not work as expected.");
         }
+        
+        String typedResultStr = chr.callAs(String.class, 32);
+        if (!" ".equals(typedResultStr)) {
+            throw new IllegalStateException(
+                    "JPyCallable chr does not work as expected.");
+        }
+
         PyCallable count = jep.getValue("[1,2,1,4,1,4].count",
                 PyCallable.class);
         result = count.call(1);
         if (((Number) result).intValue() != 3) {
+            throw new IllegalStateException(
+                    "JPyCallable list.count does not work as expected.");
+        }
+
+        Long typedResultLong = count.callAs(Long.class, 4);
+        if (typedResultLong.intValue() != 2) {
             throw new IllegalStateException(
                     "JPyCallable list.count does not work as expected.");
         }

--- a/src/test/java/jep/test/TestGetJPyObject.java
+++ b/src/test/java/jep/test/TestGetJPyObject.java
@@ -155,6 +155,25 @@ public class TestGetJPyObject {
             throw new IllegalStateException(
                     "JPyCallable list.count does not work as expected.");
         }
+
+        // test that the requested return type is actually respected - if not, this would return String instead of PyObject
+        PyCallable str = jep.getValue("str", PyCallable.class);
+        PyObject typedResultObj = str.callAs(PyObject.class, 12342);
+        count = typedResultObj.getAttr("count", PyCallable.class);
+        typedResultLong = count.callAs(Long.class, "2");
+
+        if (typedResultLong.intValue() != 2) {
+            throw new IllegalStateException(
+                    "JPyCallable str.count does not work as expected.");
+        }
+
+        typedResultLong = count.callAs(Long.class, "1");
+
+        if (typedResultLong.intValue() != 1) {
+            throw new IllegalStateException(
+                    "JPyCallable str.count does not work as expected.");
+        }
+        
     }
 
     public static void testToString(Jep jep) throws JepException {


### PR DESCRIPTION
Adds overloads to `PyCallable` which mirror the respective `call` methods, but allow passing an expected `Class` for the result.