### PR TITLE
To support nix on macOS check env first for JAVA_HOME

### DIFF
--- a/commands/java.py
+++ b/commands/java.py
@@ -30,6 +30,18 @@ def get_java_home():
     if _java_home is not None:
         return _java_home
 
+    env_home = os.environ.get('JAVA_HOME')
+    if env_home:
+        if is_windows():
+           # remove quotes from each end if necessary
+            env_home = env_home.strip('"')
+        if os.path.exists(env_home):
+            _java_home = env_home
+            return env_home
+        else:
+            configure_error('Path ' + env_home +
+                            ' indicated by JAVA_HOME does not exist.')
+
     if is_osx():
         # newer macs have an executable to help us
         try:
@@ -46,18 +58,6 @@ def get_java_home():
         if os.path.exists(MAC_JAVA_HOME):
             _java_home = MAC_JAVA_HOME
             return _java_home
-
-    env_home = os.environ.get('JAVA_HOME')
-    if env_home:
-        if is_windows():
-           # remove quotes from each end if necessary
-            env_home = env_home.strip('"')
-        if os.path.exists(env_home):
-            _java_home = env_home
-            return env_home
-        else:
-            configure_error('Path ' + env_home +
-                            ' indicated by JAVA_HOME does not exist.')
 
     configure_error(
         'Please set the environment variable JAVA_HOME to a path containing the JDK.')


### PR DESCRIPTION
# Summary of change
I use [Nix Package Manager](https://nixos.org/nixpkgs/) as my package manager on macOs. The usual `/usr/libexec/java_home` command won't find the version of java installed by nix as nix does not use that at all.

My change here switches the order to detect `JAVA_HOME` to get it from the environment first and if that doesn't work then if macOs then use `/usr/libexec/java_home`

# Additional Useful Information

When using Nix as package manager on macOS this is how we set our `JAVA_HOME`:

```
export JAVA_HOME="${$(readlink -e $(type -p java))%*/bin/java}"
```

# Error when doing a pip install due to this issue

```
Collecting jep
  Using cached jep-3.9.0.tar.gz (3.0 MB)
    ERROR: Command errored out with exit status 1:
     command: /Users/salar/Learn/ip/polynote/.env/bin/python3.8 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/setup.py'"'"'; __file__='"'"'/private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/pip-egg-info
         cwd: /private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/
    Complete output (9 lines):
    numpy not found, running without numpy support
    Traceback (most recent call last):
      File "/private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/commands/java.py", line 36, in get_java_home
        result = shell('/usr/libexec/java_home')
      File "/private/var/folders/m3/nr8nb7395yjc13hg5qf44djm0000gn/T/pip-install-kus864dt/jep/commands/util.py", line 104, in shell
        raise CommandError(message=msg, result=result)
    commands.util.CommandError: Encountered an error (return code 1) while executing '/usr/libexec/java_home'
    Error:
    Include folder should be at '/System/Library/Frameworks/JavaVM.framework/Headers' but doesn't exist. Please check you've installed the JDK properly.
```

# Notes
Any questions or anything I can help with please let me know. Many thanks for taking the time review this change and thank you for an awesome project.
