### PR TITLE
Postponed Jep initialization to support decouple init/execution of interpreter on different threads

### DIFF
--- a/src/test/java/jep/test/TestPostponeInit.java
+++ b/src/test/java/jep/test/TestPostponeInit.java
@@ -1,0 +1,70 @@
+package jep.test;
+
+import jep.Jep;
+import jep.JepConfig;
+
+import java.lang.Boolean;
+import java.lang.Exception;
+import java.lang.StringBuilder;
+import java.lang.System;
+import java.lang.Thread;
+
+/**
+ * Test that we can postpone the initialization of the Jep instance
+ *
+ * Created: June 2019
+ *
+ * @author Aitor Hernandez
+ */
+public class TestPostponeInit extends Thread{
+
+    public static void main(String[] args) throws Throwable{
+        TestPostponeInit[] t = new TestPostponeInit[16];
+        for(int i = 0 ; i < t.length ; i += 1){
+            t[i] = new TestPostponeInit();
+            t[i].start();
+        }
+        for(int i = 0 ; i < t.length ; i += 1){
+            t[i].join();
+            if( t[i].e != null ){
+                throw t[i].e;
+            }
+        }
+        JepConfig config = new JepConfig();
+        boolean useSubinterpreter = true;
+        boolean postponeInit = true;
+
+        try(Jep jep = new Jep(config, postponeInit)){
+            if (jep.isInitialized() == true){
+                System.exit(1);
+            }
+            jep.init();
+            jep.eval("success = True");
+            Thread.sleep(10);
+            Object success = jep.getValue("success");
+            if(!Boolean.TRUE.equals(success)){
+                System.exit(1);
+            }
+        }
+
+    }
+
+    public Exception e = null;
+
+    @Override
+    public void run() {
+        try(Jep jep = new Jep(new JepConfig(), true)){
+            if (jep.isInitialized() == true){
+                throw new Exception("Jep is already initialized!");
+            }
+            jep.eval("success = True");
+            Object success = jep.getValue("success");
+            if(!Boolean.TRUE.equals(success)){
+                throw new Exception("'success' variable not set in python");
+            }
+        } catch (Exception e){
+            this.e = e;
+        }
+    }
+
+}

--- a/src/test/python/test_postpone_init.py
+++ b/src/test/python/test_postpone_init.py
@@ -1,0 +1,12 @@
+import unittest
+import sys
+from jep_pipe import jep_pipe
+from jep_pipe import build_java_process_cmd
+import jep
+
+
+@unittest.skipIf(sys.platform.startswith("win"), "subprocess complications on Windows")
+class TestPostponeInit(unittest.TestCase):
+
+    def test_postpone_init(self):
+        jep_pipe(build_java_process_cmd('jep.test.TestPostponeInit'))


### PR DESCRIPTION
Hi,

I have added small modifications to be able to support a postponed initialization of the Jep Instance. 
There is a need to have a postponed initialization when when the create of the Jep, and its usage are done on different threads. 

The quick solution I provided is by exposing a boolean into the Jep constructor. Howeve, I see that the latest versions has the *useSubInterpreter*, which then means that this version will not be backwards compatibly.

BR,

//Aitor