### PR TITLE
Add tab completion to console.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004 - 2019 JEP AUTHORS.
+Copyright (c) 2004 - 2020 JEP AUTHORS.
 
 This file is licenced under the the zlib/libpng License.
 

--- a/commands/java.py
+++ b/commands/java.py
@@ -30,6 +30,18 @@ def get_java_home():
     if _java_home is not None:
         return _java_home
 
+    env_home = os.environ.get('JAVA_HOME')
+    if env_home:
+        if is_windows():
+           # remove quotes from each end if necessary
+            env_home = env_home.strip('"')
+        if os.path.exists(env_home):
+            _java_home = env_home
+            return env_home
+        else:
+            configure_error('Path ' + env_home +
+                            ' indicated by JAVA_HOME does not exist.')
+
     if is_osx():
         # newer macs have an executable to help us
         try:
@@ -46,18 +58,6 @@ def get_java_home():
         if os.path.exists(MAC_JAVA_HOME):
             _java_home = MAC_JAVA_HOME
             return _java_home
-
-    env_home = os.environ.get('JAVA_HOME')
-    if env_home:
-        if is_windows():
-           # remove quotes from each end if necessary
-            env_home = env_home.strip('"')
-        if os.path.exists(env_home):
-            _java_home = env_home
-            return env_home
-        else:
-            configure_error('Path ' + env_home +
-                            ' indicated by JAVA_HOME does not exist.')
 
     configure_error(
         'Please set the environment variable JAVA_HOME to a path containing the JDK.')

--- a/commands/java.py
+++ b/commands/java.py
@@ -208,7 +208,7 @@ class setup_java(Command):
                     'INFO: the MACOSX_DEPLOYMENT_TARGET environment variable is set:', target)
 
                 result = shell('sw_vers -productVersion')
-                if target.split('.')[:2] != result.stdout.split('.')[:2]:
+                if target.split('.')[:2] != result.stdout.decode("utf-8").split('.')[:2]:
                     warning(
                         'This target appears to be incorrect for the system version:', result.stdout)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>black.ninia</groupId>
   <artifactId>jep</artifactId>
-  <version>3.9.0</version>
+  <version>3.9.1</version>
   <packaging>jar</packaging>
 
   <name>Java Embedded Python</name>
@@ -39,7 +39,7 @@
   <scm>
     <connection>scm:git:git://github.com/ninia/jep.git</connection>
     <developerConnection>scm:git:ssh://github.com:ninia/jep.git</developerConnection>
-    <url>https://github.com/ninia/jep/tree/v3.9.0</url>
+    <url>https://github.com/ninia/jep/tree/v3.9.1</url>
    </scm>
 
   <properties>

--- a/src/main/c/Include/jep_util.h
+++ b/src/main/c/Include/jep_util.h
@@ -135,6 +135,7 @@ extern jclass JDOUBLE_ARRAY_TYPE;
     F(JMEMBER_TYPE, "java/lang/reflect/Member") \
     F(JMETHOD_TYPE, "java/lang/reflect/Method") \
     F(JFIELD_TYPE, "java/lang/reflect/Field") \
+    F(JAVA_PROXY_TYPE, "java/lang/reflect/Proxy") \
     F(JCONSTRUCTOR_TYPE, "java/lang/reflect/Constructor") \
     F(JTHROWABLE_TYPE, "java/lang/Throwable") \
     F(JMODIFIER_TYPE, "java/lang/reflect/Modifier") \
@@ -142,7 +143,7 @@ extern jclass JDOUBLE_ARRAY_TYPE;
     F(JHASHMAP_TYPE, "java/util/HashMap") \
     F(JCOLLECTIONS_TYPE, "java/util/Collections") \
     F(JCLASSLOADER_TYPE, "java/lang/ClassLoader") \
-    F(JPROXY_TYPE, "jep/Proxy") \
+    F(JEP_PROXY_TYPE, "jep/Proxy") \
     F(CLASSNOTFOUND_EXC_TYPE, "java/lang/ClassNotFoundException") \
     F(INDEX_EXC_TYPE, "java/lang/IndexOutOfBoundsException") \
     F(IO_EXC_TYPE, "java/io/IOException") \

--- a/src/main/c/Jep/java_access/Proxy.c
+++ b/src/main/c/Jep/java_access/Proxy.c
@@ -37,10 +37,10 @@ jobject jep_Proxy_newProxyInstance(JNIEnv* env, jobject jep, jlong ltarget,
     jobject result = NULL;
     Py_BEGIN_ALLOW_THREADS
     if (newProxyInstance
-            || (newProxyInstance = (*env)->GetStaticMethodID(env, JPROXY_TYPE,
+            || (newProxyInstance = (*env)->GetStaticMethodID(env, JEP_PROXY_TYPE,
                                    "newProxyInstance",
                                    "(Ljep/Jep;J[Ljava/lang/String;)Ljava/lang/Object;"))) {
-        result = (*env)->CallStaticObjectMethod(env, JPROXY_TYPE, newProxyInstance,
+        result = (*env)->CallStaticObjectMethod(env, JEP_PROXY_TYPE, newProxyInstance,
                                                 jep, ltarget, interfaces);
     }
     Py_END_ALLOW_THREADS
@@ -54,10 +54,10 @@ jobject jep_Proxy_newDirectProxyInstance(JNIEnv* env, jobject jep,
     jobject result = NULL;
     Py_BEGIN_ALLOW_THREADS
     if (newDirectProxyInstance
-            || (newDirectProxyInstance = (*env)->GetStaticMethodID(env, JPROXY_TYPE,
+            || (newDirectProxyInstance = (*env)->GetStaticMethodID(env, JEP_PROXY_TYPE,
                                          "newDirectProxyInstance",
                                          "(Ljep/Jep;JLjava/lang/Class;)Ljava/lang/Object;"))) {
-        result = (*env)->CallStaticObjectMethod(env, JPROXY_TYPE,
+        result = (*env)->CallStaticObjectMethod(env, JEP_PROXY_TYPE,
                                                 newDirectProxyInstance,
                                                 jep, ltarget, targetInterface);
     }
@@ -70,10 +70,10 @@ jobject jep_Proxy_getPyObject(JNIEnv* env, jobject object)
     jobject result = NULL;
     Py_BEGIN_ALLOW_THREADS
     if (getPyObject
-            || (getPyObject = (*env)->GetStaticMethodID(env, JPROXY_TYPE,
+            || (getPyObject = (*env)->GetStaticMethodID(env, JEP_PROXY_TYPE,
                               "getPyObject",
                               "(Ljava/lang/Object;)Ljep/python/PyObject;"))) {
-        result = (*env)->CallStaticObjectMethod(env, JPROXY_TYPE, getPyObject, object);
+        result = (*env)->CallStaticObjectMethod(env, JEP_PROXY_TYPE, getPyObject, object);
     }
     Py_END_ALLOW_THREADS
     return result;

--- a/src/main/python/jep/console.py
+++ b/src/main/python/jep/console.py
@@ -74,6 +74,12 @@ except OSError as e:
 
 if has_readline:
     try:
+        import rlcompleter
+        readline.set_completer(rlcompleter.Completer(locals()).complete)
+        readline.parse_and_bind("tab: complete")
+    except:
+        pass
+    try:
         history_file = os.path.join(os.path.expanduser('~'), '.jep')
         if not os.path.exists(history_file):
             readline.write_history_file(history_file)

--- a/src/main/python/jep/version.py
+++ b/src/main/python/jep/version.py
@@ -23,5 +23,5 @@
 #     distribution.
 #
 
-__VERSION__ = '3.9.0'
+__VERSION__ = '3.9.1'
 VERSION = __VERSION__

--- a/src/test/java/jep/test/TestSharedModulesThreads.java
+++ b/src/test/java/jep/test/TestSharedModulesThreads.java
@@ -49,7 +49,6 @@ public class TestSharedModulesThreads extends Thread {
             testFunction.append("    success = True");
             interp.eval(testFunction.toString());
             interp.eval("t = threading.Thread(target=testFunction)");
-            interp.eval("t.daemon = True");
             interp.eval("t.start()");
             interp.eval("t.join()");
             /*


### PR DESCRIPTION
The regular Python interpreter supports tab completion out of the
box. The JEP interpreter should as well.

Ben Steffensmeier proposed this solution in the discussion of
issue https://github.com/ninia/jep/issues/235 .

Test Plan:
1. Copy console.py to the location of JEP in your Python
   installation.
2. Execute `jep`.
3. Verify that tab completion works by executing
   `readline.<tab><tab>`.

I ran through the above test plan in the following environments:
* Debian Buster v10 / Python 3.8.2 / Java 11.0.6
* macOS Mojave 10.14.6 / Python 3.7.6 / Java 11.0.5
* Alpine Linux 3.10 / Python 2.7.17 / Java 11.0.4
* Windows 8.1 Pro / Python 3.8.2 / Java 11.0.5