### PR TITLE
Add tab completion to console.py

### DIFF
--- a/src/main/python/jep/console.py
+++ b/src/main/python/jep/console.py
@@ -74,6 +74,12 @@ except OSError as e:
 
 if has_readline:
     try:
+        import rlcompleter
+        readline.set_completer(rlcompleter.Completer(locals()).complete)
+        readline.parse_and_bind("tab: complete")
+    except:
+        pass
+    try:
         history_file = os.path.join(os.path.expanduser('~'), '.jep')
         if not os.path.exists(history_file):
             readline.write_history_file(history_file)


### PR DESCRIPTION
The regular Python interpreter supports tab completion out of the
box. The JEP interpreter should as well.

Ben Steffensmeier proposed this solution in the discussion of
issue https://github.com/ninia/jep/issues/235 .

Test Plan:
1. Copy console.py to the location of JEP in your Python
   installation.
2. Execute `jep`.
3. Verify that tab completion works by executing
   `readline.<tab><tab>`.

I ran through the above test plan in the following environments:
* Debian Buster v10 / Python 3.8.2 / Java 11.0.6
* macOS Mojave 10.14.6 / Python 3.7.6 / Java 11.0.5
* Alpine Linux 3.10 / Python 2.7.17 / Java 11.0.4
* Windows 8.1 Pro / Python 3.8.2 / Java 11.0.5