### PR TITLE
Add a link to CONTRIBUTION.md to the root README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ Help
 * `JavaDoc <https://ninia.github.io/jep/javadoc>`_
 * `Mailing List <https://groups.google.com/d/forum/jep-project>`_
 * `Known Issues <https://github.com/ninia/jep/issues>`_
+* `Contribution Guidelines <https://github.com/ninia/jep/blob/master/.github/CONTRIBUTING.md>`_
 * `Project Page <https://github.com/ninia/jep>`_
 
 We welcome comments, contributions, bug reports, wiki documentation, etc.


### PR DESCRIPTION
Since `CONTRIBUTION.md` is not in the root of the project, novice
GitHub users may not know to look in the `.github` folder to find
it.

Adding a link to `CONTRIBUTION.md` to the root `README.rst` gives
more visibility to these guidelines.

For those that want to know more about `CONTRIBUTION.md`, see
https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors .