### PR TITLE
Removed python2 support

### DIFF
--- a/src/main/c/Include/convert_j2p.h
+++ b/src/main/c/Include/convert_j2p.h
@@ -38,16 +38,9 @@
 #define _Included_convert_j2p
 
 #define jboolean_As_PyObject PyBool_FromLong
-
-#if PY_MAJOR_VERSION >= 3
-    #define jbyte_As_PyObject PyLong_FromLong
-    #define jshort_As_PyObject PyLong_FromLong
-    #define jint_As_PyObject PyLong_FromLong
-#else
-    #define jbyte_As_PyObject PyInt_FromLong
-    #define jshort_As_PyObject PyInt_FromLong
-    #define jint_As_PyObject PyInt_FromLong
-#endif
+#define jbyte_As_PyObject PyLong_FromLong
+#define jshort_As_PyObject PyLong_FromLong
+#define jint_As_PyObject PyLong_FromLong
 
 #define jlong_As_PyObject PyLong_FromLongLong
 

--- a/src/main/c/Include/jep_platform.h
+++ b/src/main/c/Include/jep_platform.h
@@ -74,34 +74,23 @@
     */
     #define JLOCAL_REFS 16
 
-    /* Python 2 compatibility */
-    #if PY_MAJOR_VERSION < 3
-        #define Py_hash_t long
-    #endif
+    // see https://mail.python.org/pipermail/python-porting/2012-April/000289.html
+    #define Py_TPFLAGS_HAVE_ITER 0
 
-    /* Python 3 compatibility */
-    #if PY_MAJOR_VERSION >= 3
+    /* Python 3 does not support integers, only longs */
+    #define PyInt_AsLong(i)                   PyLong_AsLongLong(i)
+    #define PyInt_AS_LONG(i)                  PyLong_AsLongLong(i)
+    #define PyInt_Check(i)                    PyLong_Check(i)
+    #define PyInt_FromLong(i)                 PyLong_FromLongLong(i)
 
-        // see https://mail.python.org/pipermail/python-porting/2012-April/000289.html
-        #define Py_TPFLAGS_HAVE_ITER 0
+    /* Python 3 separated Strings into PyBytes and PyUnicode */
+    #define PyString_FromString(str)          PyUnicode_FromString(str)
+    #define PyString_Check(str)               PyUnicode_Check(str)
+    #define PyString_FromFormat(fmt, ...)     PyUnicode_FromFormat(fmt, ##__VA_ARGS__)
 
-        /* Python 3 does not support integers, only longs */
-        #define PyInt_AsLong(i)                   PyLong_AsLongLong(i)
-        #define PyInt_AS_LONG(i)                  PyLong_AsLongLong(i)
-        #define PyInt_Check(i)                    PyLong_Check(i)
-        #define PyInt_FromLong(i)                 PyLong_FromLongLong(i)
-
-        /* Python 3 separated Strings into PyBytes and PyUnicode */
-        #define PyString_FromString(str)          PyUnicode_FromString(str)
-        #define PyString_Check(str)               PyUnicode_Check(str)
-        #define PyString_FromFormat(fmt, ...)     PyUnicode_FromFormat(fmt, ##__VA_ARGS__)
-
-        #define PyString_AsString(str)            PyUnicode_AsUTF8(str)
-        #define PyString_AS_STRING(str)           PyUnicode_AsUTF8(str)
-        #define PyString_Size(str)                PyUnicode_GetLength(str)
-        #define PyString_GET_SIZE(str)            PyUnicode_GET_LENGTH(str)
-
-    #endif // Python 3 compatibility
-
+    #define PyString_AsString(str)            PyUnicode_AsUTF8(str)
+    #define PyString_AS_STRING(str)           PyUnicode_AsUTF8(str)
+    #define PyString_Size(str)                PyUnicode_GetLength(str)
+    #define PyString_GET_SIZE(str)            PyUnicode_GET_LENGTH(str)
 
 #endif // ifndef _Included_jep_platform

--- a/src/main/c/Include/jep_platform.h
+++ b/src/main/c/Include/jep_platform.h
@@ -74,23 +74,4 @@
     */
     #define JLOCAL_REFS 16
 
-    // see https://mail.python.org/pipermail/python-porting/2012-April/000289.html
-    #define Py_TPFLAGS_HAVE_ITER 0
-
-    /* Python 3 does not support integers, only longs */
-    #define PyInt_AsLong(i)                   PyLong_AsLongLong(i)
-    #define PyInt_AS_LONG(i)                  PyLong_AsLongLong(i)
-    #define PyInt_Check(i)                    PyLong_Check(i)
-    #define PyInt_FromLong(i)                 PyLong_FromLongLong(i)
-
-    /* Python 3 separated Strings into PyBytes and PyUnicode */
-    #define PyString_FromString(str)          PyUnicode_FromString(str)
-    #define PyString_Check(str)               PyUnicode_Check(str)
-    #define PyString_FromFormat(fmt, ...)     PyUnicode_FromFormat(fmt, ##__VA_ARGS__)
-
-    #define PyString_AsString(str)            PyUnicode_AsUTF8(str)
-    #define PyString_AS_STRING(str)           PyUnicode_AsUTF8(str)
-    #define PyString_Size(str)                PyUnicode_GetLength(str)
-    #define PyString_GET_SIZE(str)            PyUnicode_GET_LENGTH(str)
-
 #endif // ifndef _Included_jep_platform

--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -42,9 +42,6 @@ struct __JepThread {
     jobject        caller;      /* Jep instance that called us. */
     PyObject      *fqnToPyJAttrs; /* a dictionary of fully qualified Java
                                        classnames to PyJMethods and PyJFields */
-#if PY_MAJOR_VERSION < 3
-    PyObject      *originalBuiltins;
-#endif
 };
 typedef struct __JepThread JepThread;
 

--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -59,7 +59,7 @@ static void raiseTypeError(JNIEnv *env, PyObject *pyobject, jclass expectedType)
     if (PyJClass_Check(pyobject)) {
         actTypeName = "java.lang.Class";
     } else if (PyJObject_Check(pyobject)) {
-        actTypeName = PyString_AsString(((PyJObject*) pyobject)->javaClassName);
+        actTypeName = PyUnicode_AsUTF8(((PyJObject*) pyobject)->javaClassName);
     } else {
         actTypeName = pyobject->ob_type->tp_name;
     }

--- a/src/main/c/Jep/jep_exceptions.c
+++ b/src/main/c/Jep/jep_exceptions.c
@@ -94,13 +94,6 @@ int process_py_exception(JNIEnv *env)
                  * there is an except: block even if the error is not actually
                  * caught.
                  */
-#if PY_MAJOR_VERSION < 3
-                PyObject *message = PyObject_GetAttrString(pvalue, "message");
-                if (message != NULL && PyJObject_Check(message)) {
-                    Py_DECREF(pvalue);
-                    pvalue = message;
-                }
-#else
                 PyObject *args = PyObject_GetAttrString(pvalue, "args");
                 if (args != NULL && PyTuple_Check(args) && PyTuple_Size(args) > 0) {
                     PyObject *message = PyTuple_GetItem(args, 0);
@@ -109,7 +102,6 @@ int process_py_exception(JNIEnv *env)
                     Py_DECREF(args);
                     pvalue = message;
                 }
-#endif
             }
 
 
@@ -139,12 +131,7 @@ int process_py_exception(JNIEnv *env)
 
             if (v != NULL && PyString_Check(v)) {
                 PyObject *t;
-#if PY_MAJOR_VERSION >= 3
                 t = PyUnicode_FromFormat("%U: %U", message, v);
-#else
-                t = PyString_FromFormat("%s: %s", PyString_AsString(message),
-                                        PyString_AsString(v));
-#endif
                 Py_DECREF(v);
                 Py_DECREF(message);
                 message = t;

--- a/src/main/c/Jep/jep_exceptions.c
+++ b/src/main/c/Jep/jep_exceptions.c
@@ -129,14 +129,14 @@ int process_py_exception(JNIEnv *env)
                 v = PyObject_Str(pvalue);
             }
 
-            if (v != NULL && PyString_Check(v)) {
+            if (v != NULL && PyUnicode_Check(v)) {
                 PyObject *t;
                 t = PyUnicode_FromFormat("%U: %U", message, v);
                 Py_DECREF(v);
                 Py_DECREF(message);
                 message = t;
             }
-            m = PyString_AsString(message);
+            m = PyUnicode_AsUTF8(message);
 
             // make a JepException
             jmsg = (*env)->NewStringUTF(env, (const char *) m);
@@ -174,7 +174,7 @@ int process_py_exception(JNIEnv *env)
                 if (modTB == NULL) {
                     printf("Error importing python traceback module\n");
                 }
-                extract = PyString_FromString("extract_tb");
+                extract = PyUnicode_FromString("extract_tb");
                 if (extract == NULL) {
                     printf("Error making PyString 'extract_tb'\n");
                 }
@@ -236,11 +236,11 @@ int process_py_exception(JNIEnv *env)
                     stackEntry = PyList_GetItem(pystack, i);
                     // java order is classname, method name, filename, line number
                     // python order is filename, line number, function name, line
-                    charPyFile = PyString_AsString(
+                    charPyFile = PyUnicode_AsUTF8(
                                      PySequence_GetItem(stackEntry, 0));
-                    pyLineNum = (int) PyInt_AsLong(
+                    pyLineNum = (int) PyLong_AsLongLong(
                                     PySequence_GetItem(stackEntry, 1));
-                    charPyFunc = PyString_AsString(
+                    charPyFunc = PyUnicode_AsUTF8(
                                      PySequence_GetItem(stackEntry, 2));
                     pyLine = PySequence_GetItem(stackEntry, 3);
 
@@ -377,9 +377,9 @@ int process_py_exception(JNIEnv *env)
     if (jepException != NULL) {
         Py_DECREF(message);
         THROW_JEP_EXC(env, jepException);
-    } else if (message && PyString_Check(message)) {
+    } else if (message && PyUnicode_Check(message)) {
         // should only get here if there was a ptype but no pvalue
-        m = PyString_AsString(message);
+        m = PyUnicode_AsUTF8(message);
         THROW_JEP(env, m);
         Py_DECREF(message);
     }

--- a/src/main/c/Jep/jep_numpy.c
+++ b/src/main/c/Jep/jep_numpy.c
@@ -55,22 +55,13 @@ static jobject NATIVE_BYTE_ORDER  = NULL;
 
 /*
  * Initializes the numpy extension library.  This is required to be called
- * once and only once, before any PyArray_ methods are called. Unfortunately
- * it needs to have a different return type in Python 2 vs Python 3.
+ * once and only once, before any PyArray_ methods are called.
  */
-#if PY_MAJOR_VERSION >= 3
 static PyObject* _init_numpy(void)
 {
     import_array();
     return NULL;
 }
-#else
-static void _init_numpy(void)
-{
-    import_array();
-}
-#endif // Python 3 compatibility
-
 static int init_numpy(void)
 {
     if (!numpyInitialized) {

--- a/src/main/c/Jep/jep_util.c
+++ b/src/main/c/Jep/jep_util.c
@@ -427,7 +427,7 @@ int pyarg_matches_jtype(JNIEnv *env,
                 return 2;
             }
         }
-    } else if (PyInt_Check(param)) {
+    } else if (PyLong_Check(param)) {
         switch (paramTypeId) {
         case JINT_ID:
             return 11;
@@ -454,12 +454,12 @@ int pyarg_matches_jtype(JNIEnv *env,
                 return 2;
             }
         }
-    } else if (PyString_Check(param)) {
+    } else if (PyUnicode_Check(param)) {
         switch (paramTypeId) {
         case JSTRING_ID:
             return 3;
         case JCHAR_ID:
-            if (PyString_GET_SIZE(param) == 1) {
+            if (PyUnicode_GET_LENGTH(param) == 1) {
                 return 2;
             }
             break;
@@ -595,7 +595,7 @@ jvalue convert_pyarg_jvalue(JNIEnv *env, PyObject *param, jclass paramType,
             pvalue_string = PyObject_Str(pvalue);
         }
         PyErr_Format(PyExc_TypeError, "Error converting parameter %d: %s", pos + 1,
-                     PyString_AsString(pvalue_string));
+                     PyUnicode_AsUTF8(pvalue_string));
         Py_DECREF(pvalue_string);
         Py_DECREF(ptype);
         Py_XDECREF(pvalue);

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -120,8 +120,6 @@ static struct PyMethodDef jep_methods[] = {
 
     { NULL, NULL }
 };
-
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef jep_module_def = {
     PyModuleDef_HEAD_INIT,
     "_jep",              /* m_name */
@@ -133,13 +131,10 @@ static struct PyModuleDef jep_module_def = {
     NULL,                /* m_clear */
     NULL,                /* m_free */
 };
-#endif
 
 static PyObject* initjep(JNIEnv *env, jboolean hasSharedModules)
 {
     PyObject *modjep;
-
-#if PY_MAJOR_VERSION >= 3
     PyObject *sysmodules;
     modjep = PyModule_Create(&jep_module_def);
     if (modjep == NULL) {
@@ -151,18 +146,6 @@ static PyObject* initjep(JNIEnv *env, jboolean hasSharedModules)
         handle_startup_exception(env, "Couldn't set _jep on sys.modules");
         return NULL;
     }
-#else
-    modjep = PyImport_AddModule("_jep");
-    if (modjep == NULL) {
-        handle_startup_exception(env, "Couldn't add module _jep");
-        return NULL;
-    }
-    modjep = Py_InitModule((char *) "_jep", jep_methods);
-    if (modjep == NULL) {
-        handle_startup_exception(env, "Couldn't init module _jep");
-        return NULL;
-    }
-#endif
     modjep = PyImport_ImportModule("_jep");
     if (modjep == NULL) {
         handle_startup_exception(env, "Couldn't import module _jep");
@@ -222,18 +205,12 @@ void pyembed_preinit(JNIEnv *env,
     }
     if (pythonHome) {
         const char* homeAsUTF = (*env)->GetStringUTFChars(env, pythonHome, NULL);
-#if PY_MAJOR_VERSION >= 3
 #if PY_MAJOR_VERSION > 3 || PY_MINOR_VERSION >= 5
         wchar_t* homeForPython = Py_DecodeLocale(homeAsUTF, NULL);
 #else
         int length = (*env)->GetStringUTFLength(env, pythonHome);
         wchar_t* homeForPython = malloc((length + 1) * sizeof(wchar_t));
         mbstowcs(homeForPython, homeAsUTF, length + 1);
-#endif
-#else
-        int length = (*env)->GetStringUTFLength(env, pythonHome);
-        char* homeForPython = malloc(length);
-        strncpy(homeForPython, homeAsUTF, length);
 #endif
         (*env)->ReleaseStringUTFChars(env, pythonHome, homeAsUTF);
 
@@ -457,39 +434,6 @@ void pyembed_startup(JNIEnv *env, jobjectArray sharedModulesArgv)
      * See github issue #81.
      */
     if (sharedModulesArgv != NULL) {
-#if PY_MAJOR_VERSION < 3
-        char **argv = NULL;
-        jsize count = 0;
-        int i       = 0;
-
-        count = (*env)->GetArrayLength(env, sharedModulesArgv);
-        (*env)->PushLocalFrame(env, count * 2);
-        argv = (char**) malloc(count * sizeof(char*));
-        for (i = 0; i < count; i++) {
-            char* arg = NULL;
-
-            jstring jarg = (*env)->GetObjectArrayElement(env, sharedModulesArgv, i);
-            if (jarg == NULL) {
-                PyEval_ReleaseThread(mainThreadState);
-                (*env)->PopLocalFrame(env, NULL);
-                THROW_JEP(env, "Received null argv.");
-                return;
-            }
-            arg = (char*) (*env)->GetStringUTFChars(env, jarg, NULL);
-            argv[i] = arg;
-        }
-
-        PySys_SetArgvEx(count, argv, 0);
-
-        // free memory
-        for (i = 0; i < count; i++) {
-            jstring jarg = (*env)->GetObjectArrayElement(env, sharedModulesArgv, i);
-            (*env)->ReleaseStringUTFChars(env, jarg, argv[i]);
-        }
-        free(argv);
-        (*env)->PopLocalFrame(env, NULL);
-
-#else
         wchar_t **argv = NULL;
         jsize count = 0;
         int i       = 0;
@@ -523,8 +467,6 @@ void pyembed_startup(JNIEnv *env, jobjectArray sharedModulesArgv)
         }
         free(argv);
         (*env)->PopLocalFrame(env, NULL);
-
-#endif
     }
 
     PyEval_ReleaseThread(mainThreadState);
@@ -620,79 +562,6 @@ void pyembed_shared_import(JNIEnv *env, jstring module)
     PyEval_ReleaseThread(mainThreadState);
 }
 
-#if PY_MAJOR_VERSION < 3
-/*
- * In python 2.7 when a module is shared between threads it will be run in
- * restricted mode because the __builtins__ attribute of the module does not
- * match the running interpreter. This causes some functionality to break.
- * To get around this limitation the builtins module is shared between all the
- * interpreters that are using shared modules.
- *
- * This is not necessary in python 3 because restricted mode was removed.
- */
-
-void assignBuiltins(PyObject* modules, PyObject* builtins)
-{
-    PyObject *key, *value;
-    Py_ssize_t pos = 0;
-
-    while (PyDict_Next(modules, &pos, &key, &value)) {
-        PyObject* moddict = PyModule_GetDict(value);
-        if (moddict) {
-            PyDict_SetItemString(moddict, "__builtins__", builtins);
-        }
-    }
-}
-
-void shareBuiltins(JepThread *jepThread)
-{
-    PyInterpreterState* interp = jepThread->tstate->interp;
-
-    PyObject* sharedBuiltinModule = PyDict_GetItemString(mainThreadModules,
-                                    "__builtin__");
-    PyObject* sharedBuiltinDict   = PyModule_GetDict(sharedBuiltinModule);
-
-    PyObject* originalBuiltinModule = PyDict_GetItemString(interp->modules,
-                                      "__builtin__");
-    PyObject* originalBuiltinDict   = interp->builtins;
-
-    Py_INCREF(sharedBuiltinDict);
-    interp->builtins = sharedBuiltinDict;
-    Py_DECREF(originalBuiltinDict);
-
-    // Incref to make sure this isn't collected when it is replaced, it
-    // will be restored when the itnterpreter is closed.
-    Py_INCREF(originalBuiltinModule);
-
-    PyDict_SetItemString(interp->modules, "__builtin__", sharedBuiltinModule);
-    assignBuiltins(interp->modules, sharedBuiltinDict);
-
-    jepThread->originalBuiltins = originalBuiltinModule;
-}
-
-void unshareBuiltins(JepThread *jepThread)
-{
-    PyInterpreterState* interp = jepThread->tstate->interp;
-
-    PyObject* originalBuiltinModule = jepThread->originalBuiltins;
-    PyObject* originalBuiltinDict   = PyModule_GetDict(originalBuiltinModule);
-
-    PyObject* sharedBuiltinDict   = interp->builtins;
-
-    Py_INCREF(originalBuiltinDict);
-    interp->builtins = originalBuiltinDict;
-    Py_DECREF(sharedBuiltinDict);
-
-    PyDict_SetItemString(interp->modules, "__builtin__", originalBuiltinModule);
-
-    assignBuiltins(interp->modules, originalBuiltinDict);
-
-    jepThread->originalBuiltins = NULL;
-    Py_DECREF(originalBuiltinModule);
-}
-
-#endif
-
 intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
                              jboolean hasSharedModules, jboolean usesubinterpreter)
 {
@@ -719,13 +588,6 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
         PyEval_AcquireThread(mainThreadState);
 
         jepThread->tstate = Py_NewInterpreter();
-#if PY_MAJOR_VERSION < 3
-        if (hasSharedModules) {
-            shareBuiltins(jepThread);
-        } else {
-            jepThread->originalBuiltins = NULL;
-        }
-#endif
 
         /*
          * Py_NewInterpreter() seems to take the thread state, but we're going to
@@ -734,9 +596,6 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
         PyEval_SaveThread();
     } else {
         jepThread->tstate = PyThreadState_New(mainThreadState->interp);
-#if PY_MAJOR_VERSION < 3
-        jepThread->originalBuiltins = NULL;
-#endif
     }
     PyEval_AcquireThread(jepThread->tstate);
 
@@ -773,12 +632,7 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
 
     if ((tdict = PyThreadState_GetDict()) != NULL) {
         PyObject *key, *t;
-
-#if PY_MAJOR_VERSION >= 3
         t   = PyCapsule_New((void *) jepThread, NULL, NULL);
-#else
-        t   = (PyObject *) PyCObject_FromVoidPtr((void *) jepThread, NULL);
-#endif
         key = PyString_FromString(DICT_KEY);
 
         PyDict_SetItem(tdict, key, t);   /* takes ownership */
@@ -804,11 +658,6 @@ void pyembed_thread_close(JNIEnv *env, intptr_t _jepThread)
     }
 
     PyEval_AcquireThread(jepThread->tstate);
-#if PY_MAJOR_VERSION < 3
-    if (jepThread->originalBuiltins) {
-        unshareBuiltins(jepThread);
-    }
-#endif
     key = PyString_FromString(DICT_KEY);
     if ((tdict = PyThreadState_GetDict()) != NULL && key != NULL) {
         PyDict_DelItem(tdict, key);
@@ -870,11 +719,7 @@ JepThread* pyembed_get_jepthread(void)
     if ((tdict = PyThreadState_GetDict()) != NULL && key != NULL) {
         t = PyDict_GetItem(tdict, key); /* borrowed */
         if (t != NULL && !PyErr_Occurred()) {
-#if PY_MAJOR_VERSION >= 3
             ret = (JepThread*) PyCapsule_GetPointer(t, NULL);
-#else
-            ret = (JepThread*) PyCObject_AsVoidPtr(t);
-#endif
         }
     }
     Py_XDECREF(key);
@@ -1540,8 +1385,6 @@ jobject pyembed_getvalue_array(JNIEnv *env, intptr_t _jepThread, char *str)
     if (result == NULL || result == Py_None) {
         goto EXIT;    /* don't return, need to release GIL */
     }
-
-#if PY_MAJOR_VERSION >= 3
     if (PyBytes_Check(result) == 0) {
         PyObject *temp = PyBytes_FromObject(result);
         if (process_py_exception(env) || result == NULL) {
@@ -1551,7 +1394,6 @@ jobject pyembed_getvalue_array(JNIEnv *env, intptr_t _jepThread, char *str)
             result = temp;
         }
     }
-#endif
 
     if (PyBytes_Check(result)) {
         void *s = (void*) PyBytes_AS_STRING(result);
@@ -1649,14 +1491,12 @@ static void pyembed_run_pyc(JepThread *jepThread,
         return;
     }
     (void) PyMarshal_ReadLongFromFile(fp);
-#if PY_MAJOR_VERSION >= 3
     // Python 3.3 added an extra long containing the size of the source.
     // https://github.com/python/cpython/commit/5136ac0ca21a05691978df8d0650f902c8ca3463
     (void) PyMarshal_ReadLongFromFile(fp);
 #if PY_MAJOR_VERSION > 3 || PY_MINOR_VERSION >= 7
     // PEP 552 added another long
     (void) PyMarshal_ReadLongFromFile(fp);
-#endif
 #endif
     v = (PyObject *) (intptr_t) PyMarshal_ReadLastObjectFromFile(fp);
     if (v == NULL || !PyCode_Check(v)) {
@@ -1665,12 +1505,7 @@ static void pyembed_run_pyc(JepThread *jepThread,
         return;
     }
     co = v;
-#if PY_MAJOR_VERSION >= 3
     v = PyEval_EvalCode(co, jepThread->globals, jepThread->globals);
-#else
-    v = PyEval_EvalCode((PyCodeObject *) co, jepThread->globals,
-                        jepThread->globals);
-#endif
     Py_DECREF(co);
     Py_XDECREF(v);
 }

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -633,7 +633,7 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
     if ((tdict = PyThreadState_GetDict()) != NULL) {
         PyObject *key, *t;
         t   = PyCapsule_New((void *) jepThread, NULL, NULL);
-        key = PyString_FromString(DICT_KEY);
+        key = PyUnicode_FromString(DICT_KEY);
 
         PyDict_SetItem(tdict, key, t);   /* takes ownership */
 
@@ -658,7 +658,7 @@ void pyembed_thread_close(JNIEnv *env, intptr_t _jepThread)
     }
 
     PyEval_AcquireThread(jepThread->tstate);
-    key = PyString_FromString(DICT_KEY);
+    key = PyUnicode_FromString(DICT_KEY);
     if ((tdict = PyThreadState_GetDict()) != NULL && key != NULL) {
         PyDict_DelItem(tdict, key);
     }
@@ -715,7 +715,7 @@ JepThread* pyembed_get_jepthread(void)
     PyObject  *tdict, *t, *key;
     JepThread *ret = NULL;
 
-    key = PyString_FromString(DICT_KEY);
+    key = PyUnicode_FromString(DICT_KEY);
     if ((tdict = PyThreadState_GetDict()) != NULL && key != NULL) {
         t = PyDict_GetItem(tdict, key); /* borrowed */
         if (t != NULL && !PyErr_Occurred()) {
@@ -776,11 +776,11 @@ static PyObject* pyembed_jproxy(PyObject *self, PyObject *args)
         PyObject   *item;
 
         item = PyList_GET_ITEM(interfaces, i);
-        if (!PyString_Check(item)) {
+        if (!PyUnicode_Check(item)) {
             return PyErr_Format(PyExc_ValueError, "Item %zd not a string.", i);
         }
 
-        str  = PyString_AsString(item);
+        str  = PyUnicode_AsUTF8(item);
         jstr = (*env)->NewStringUTF(env, (const char *) str);
 
         (*env)->SetObjectArrayElement(env, classes, (jsize) i, jstr);
@@ -1704,7 +1704,7 @@ void pyembed_setparameter_string(JNIEnv *env,
         Py_INCREF(Py_None);
         pyvalue = Py_None;
     } else {
-        pyvalue = PyString_FromString(value);
+        pyvalue = PyUnicode_FromString(value);
     }
 
     if (pyvalue) {

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -102,11 +102,11 @@ PyObject* pyjarray_new_v(PyObject *isnull, PyObject *args)
         return NULL;
     }
 
-    if (PyInt_Check(one)) {
-        size = (long) PyInt_AsLong(one);
+    if (PyLong_Check(one)) {
+        size = (long) PyLong_AsLongLong(one);
 
-        if (PyInt_Check(two)) {
-            typeId = (int) PyInt_AsLong(two);
+        if (PyLong_Check(two)) {
+            typeId = (int) PyLong_AsLongLong(two);
 
             if (size < 0) {
                 return PyErr_Format(PyExc_ValueError, "Invalid size %li", size);
@@ -251,8 +251,8 @@ static int pyjarray_init(JNIEnv *env,
             long  v  = 0;
             jint *ar = (jint *) pyarray->pinnedArray;
 
-            if (value && PyInt_Check(value)) {
-                v = (long) PyInt_AS_LONG(value);
+            if (value && PyLong_Check(value)) {
+                v = (long) PyLong_AsLongLong(value);
             }
 
             for (i = 0; i < pyarray->length; i++) {
@@ -267,9 +267,9 @@ static int pyjarray_init(JNIEnv *env,
             long  v = 0;
             const char *val;
             jchar *ar = (jchar *) pyarray->pinnedArray;
-            if (!value || !PyString_Check(value)) {
-                if (value && PyInt_Check(value)) {
-                    v = (long) PyInt_AS_LONG(value);
+            if (!value || !PyUnicode_Check(value)) {
+                if (value && PyLong_Check(value)) {
+                    v = (long) PyLong_AsLongLong(value);
                 }
 
                 for (i = 0; i < pyarray->length; i++) {
@@ -279,7 +279,7 @@ static int pyjarray_init(JNIEnv *env,
                 // it's a string, set the elements
                 // we won't throw an error for index, length problems. just deal...
 
-                val = PyString_AS_STRING(value);
+                val = PyUnicode_AsUTF8(value);
                 for (i = 0; i < pyarray->length && val[i] != '\0'; i++) {
                     ar[i] = (jchar) val[i];
                 }
@@ -293,8 +293,8 @@ static int pyjarray_init(JNIEnv *env,
             long   v  = 0;
             jbyte *ar = (jbyte *) pyarray->pinnedArray;
 
-            if (value && PyInt_Check(value)) {
-                v = (long) PyInt_AS_LONG(value);
+            if (value && PyLong_Check(value)) {
+                v = (long) PyLong_AsLongLong(value);
             }
 
             for (i = 0; i < pyarray->length; i++) {
@@ -314,8 +314,8 @@ static int pyjarray_init(JNIEnv *env,
             else {
                 if (PyLong_Check(value)) {
                     v = PyLong_AsLongLong(value);
-                } else if (PyInt_Check(value)) {
-                    v = PyInt_AS_LONG(value);
+                } else if (PyLong_Check(value)) {
+                    v = PyLong_AsLongLong(value);
                 }
             }
 
@@ -331,8 +331,8 @@ static int pyjarray_init(JNIEnv *env,
             long      v  = 0;
             jboolean *ar = (jboolean *) pyarray->pinnedArray;
 
-            if (value && PyInt_Check(value)) {
-                v = (long) PyInt_AS_LONG(value);
+            if (value && PyLong_Check(value)) {
+                v = (long) PyLong_AsLongLong(value);
             }
 
             for (i = 0; i < pyarray->length; i++) {
@@ -367,8 +367,8 @@ static int pyjarray_init(JNIEnv *env,
             long    v  = 0;
             jshort *ar = (jshort *) pyarray->pinnedArray;
 
-            if (value && PyInt_Check(value)) {
-                v  = (long) PyInt_AS_LONG(value);
+            if (value && PyLong_Check(value)) {
+                v  = (long) PyLong_AsLongLong(value);
             }
 
             for (i = 0; i < pyarray->length; i++) {
@@ -606,7 +606,7 @@ static int pyjarray_setitem(PyJArrayObject *self,
         if (newitem == Py_None)
             ; // setting NULL
         else {
-            if (!PyString_Check(newitem)) {
+            if (!PyUnicode_Check(newitem)) {
                 PyErr_SetString(PyExc_TypeError, "Expected string.");
                 return -1;
             }
@@ -677,28 +677,28 @@ static int pyjarray_setitem(PyJArrayObject *self,
     switch (self->componentType) {
 
     case JINT_ID:
-        if (!PyInt_Check(newitem)) {
+        if (!PyLong_Check(newitem)) {
             PyErr_SetString(PyExc_TypeError, "Expected int.");
             return -1;
         }
 
-        ((jint *) self->pinnedArray)[pos] = (jint) PyInt_AS_LONG(newitem);
+        ((jint *) self->pinnedArray)[pos] = (jint) PyLong_AsLongLong(newitem);
         return 0; /* success */
 
     case JBYTE_ID:
-        if (!PyInt_Check(newitem)) {
+        if (!PyLong_Check(newitem)) {
             PyErr_SetString(PyExc_TypeError, "Expected byte.");
             return -1;
         }
 
-        ((jbyte *) self->pinnedArray)[pos] = (jbyte) PyInt_AS_LONG(newitem);
+        ((jbyte *) self->pinnedArray)[pos] = (jbyte) PyLong_AsLongLong(newitem);
         return 0; /* success */
 
     case JCHAR_ID:
-        if (PyInt_Check(newitem)) {
-            ((jchar *) self->pinnedArray)[pos] = (jchar) PyInt_AS_LONG(newitem);
-        } else if (PyString_Check(newitem) && PyString_GET_SIZE(newitem) == 1) {
-            const char *val = PyString_AS_STRING(newitem);
+        if (PyLong_Check(newitem)) {
+            ((jchar *) self->pinnedArray)[pos] = (jchar) PyLong_AsLongLong(newitem);
+        } else if (PyUnicode_Check(newitem) && PyUnicode_GET_LENGTH(newitem) == 1) {
+            const char *val = PyUnicode_AsUTF8(newitem);
             ((jchar *) self->pinnedArray)[pos] = (jchar) val[0];
         } else {
             PyErr_SetString(PyExc_TypeError, "Expected char.");
@@ -717,12 +717,12 @@ static int pyjarray_setitem(PyJArrayObject *self,
         return 0; /* success */
 
     case JBOOLEAN_ID:
-        if (!PyInt_Check(newitem)) {
+        if (!PyLong_Check(newitem)) {
             PyErr_SetString(PyExc_TypeError, "Expected boolean.");
             return -1;
         }
 
-        if (PyInt_AS_LONG(newitem)) {
+        if (PyLong_AsLongLong(newitem)) {
             ((jboolean *) self->pinnedArray)[pos] = JNI_TRUE;
         } else {
             ((jboolean *) self->pinnedArray)[pos] = JNI_FALSE;
@@ -741,13 +741,13 @@ static int pyjarray_setitem(PyJArrayObject *self,
         return 0; /* success */
 
     case JSHORT_ID:
-        if (!PyInt_Check(newitem)) {
+        if (!PyLong_Check(newitem)) {
             PyErr_SetString(PyExc_TypeError, "Expected int.");
             return -1;
         }
 
         ((jshort *) self->pinnedArray)[pos] =
-            (jshort) PyInt_AS_LONG(newitem);
+            (jshort) PyLong_AsLongLong(newitem);
         return 0; /* success */
 
     case JFLOAT_ID:
@@ -900,7 +900,7 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
     case JSTRING_ID: {
         int i, ret = 0;
 
-        if (el != Py_None && !PyString_Check(el)) {
+        if (el != Py_None && !PyUnicode_Check(el)) {
             PyErr_SetString(PyExc_TypeError, "Expected str.");
             return -1;
         }
@@ -1020,12 +1020,12 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
         int       i;
         jboolean  v;
 
-        if (!PyInt_Check(el)) {
+        if (!PyLong_Check(el)) {
             PyErr_SetString(PyExc_TypeError, "Expected boolean.");
             return -1;
         }
 
-        if (PyInt_AS_LONG(el)) {
+        if (PyLong_AsLongLong(el)) {
             v = JNI_TRUE;
         } else {
             v = JNI_FALSE;
@@ -1045,12 +1045,12 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
         int     i;
         jshort  v;
 
-        if (!PyInt_Check(el)) {
+        if (!PyLong_Check(el)) {
             PyErr_SetString(PyExc_TypeError, "Expected int (short).");
             return -1;
         }
 
-        v = (jshort) PyInt_AS_LONG(el);
+        v = (jshort) PyLong_AsLongLong(el);
         for (i = 0; i < self->length; i++) {
             if (v == ar[i]) {
                 return i;
@@ -1065,12 +1065,12 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
         int   i;
         jint  v;
 
-        if (!PyInt_Check(el)) {
+        if (!PyLong_Check(el)) {
             PyErr_SetString(PyExc_TypeError, "Expected int.");
             return -1;
         }
 
-        v = (jint) PyInt_AS_LONG(el);
+        v = (jint) PyLong_AsLongLong(el);
         for (i = 0; i < self->length; i++) {
             if (v == ar[i]) {
                 return i;
@@ -1085,12 +1085,12 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
         int    i;
         jbyte  v;
 
-        if (!PyInt_Check(el)) {
+        if (!PyLong_Check(el)) {
             PyErr_SetString(PyExc_TypeError, "Expected byte.");
             return -1;
         }
 
-        v = (jbyte) PyInt_AS_LONG(el);
+        v = (jbyte) PyLong_AsLongLong(el);
         for (i = 0; i < self->length; i++) {
             if (v == ar[i]) {
                 return i;
@@ -1105,10 +1105,10 @@ static int pyjarray_index(PyJArrayObject *self, PyObject *el)
         int    i;
         jchar  v;
 
-        if (PyInt_Check(el)) {
-            v = (jchar) PyInt_AS_LONG(el);
-        } else if (PyString_Check(el) && PyString_GET_SIZE(el) == 1) {
-            const char *val = PyString_AS_STRING(el);
+        if (PyLong_Check(el)) {
+            v = (jchar) PyLong_AsLongLong(el);
+        } else if (PyUnicode_Check(el) && PyUnicode_GET_LENGTH(el) == 1) {
+            const char *val = PyUnicode_AsUTF8(el);
             v = (jchar) val[0];
         } else {
             PyErr_SetString(PyExc_TypeError, "Expected char.");
@@ -1208,7 +1208,7 @@ static PyObject* listindex(PyJArrayObject *self, PyObject *args)
     }
 
     if (pos >= 0) {
-        return PyInt_FromLong((long) pos);
+        return PyLong_FromLongLong((long) pos);
     }
 
     PyErr_SetString(PyExc_ValueError, "list.index(x): x not in array");
@@ -1475,8 +1475,8 @@ static PyObject* pyjarray_slice(PyObject *_self, Py_ssize_t ilow,
 // shamelessly taken from listobject.c
 static PyObject* pyjarray_subscript(PyJArrayObject *self, PyObject *item)
 {
-    if (PyInt_Check(item)) {
-        long i = (long) PyInt_AS_LONG(item);
+    if (PyLong_Check(item)) {
+        long i = (long) PyLong_AsLongLong(item);
         if (i < 0) {
             i += self->length;
         }
@@ -1601,8 +1601,7 @@ PyTypeObject PyJArray_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_HAVE_ITER,                     /* tp_flags */
+    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
     list_doc,                                 /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */
@@ -1731,8 +1730,7 @@ PyTypeObject PyJArrayIter_Type = {
     (getattrofunc) pyjarrayiter_dealloc,      /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_HAVE_ITER,                     /* tp_flags */
+    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
     0,                                        /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjbuffer.c
+++ b/src/main/c/Objects/pyjbuffer.c
@@ -107,7 +107,7 @@ getbuf(PyObject* self, Py_buffer *view, int flags)
     if (descr->type == NULL) {
         view->buf = NULL;
         PyErr_Format(PyExc_TypeError, "Python buffer access is not allowed for %s",
-                     PyString_AsString(pyjob->javaClassName));
+                     PyUnicode_AsUTF8(pyjob->javaClassName));
         return -1;
     }
     view->obj = (PyObject*)self;

--- a/src/main/c/Objects/pyjbuffer.c
+++ b/src/main/c/Objects/pyjbuffer.c
@@ -153,12 +153,6 @@ getbuf(PyObject* self, Py_buffer *view, int flags)
 
 
 static PyBufferProcs buffer_as_buffer = {
-#if PY_MAJOR_VERSION < 3
-    (readbufferproc)NULL,
-    (writebufferproc)NULL,
-    (segcountproc)NULL,
-    (charbufferproc)NULL,
-#endif
     (getbufferproc)getbuf,
     (releasebufferproc)NULL
 };
@@ -189,9 +183,6 @@ PyTypeObject PyJBuffer_Type = {
     0,                                        /* tp_setattro */
     &buffer_as_buffer,                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT |
-#if PY_MAJOR_VERSION < 3
-    Py_TPFLAGS_HAVE_NEWBUFFER |
-#endif
     Py_TPFLAGS_BASETYPE,                      /* tp_flags */
     "jbuffer",                                /* tp_doc */
     0,                                        /* tp_traverse */

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -270,12 +270,7 @@ static PyObject* pyjclass_call(PyJClassObject *self,
      * Bind the constructor to the class so that the class will
      * be the first arg when constructor is called.
      */
-#if PY_MAJOR_VERSION >= 3
     boundConstructor = PyMethod_New(self->constructor, (PyObject*) self);
-#else
-    boundConstructor = PyMethod_New(self->constructor, (PyObject*) self,
-                                    (PyObject*) Py_TYPE((PyObject*)self));
-#endif
     result = PyObject_Call(boundConstructor, args, keywords);
     Py_DECREF(boundConstructor);
     return result;

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -73,7 +73,7 @@ static PyObject* pyjclass_add_inner_class(JNIEnv *env, PyJClassObject *topClz,
         if (PyDict_SetItemString(topClz->attr, charName, attrClz) != 0) {
             printf("Error adding inner class %s\n", charName);
         } else {
-            PyObject *pyname = PyString_FromString(charName);
+            PyObject *pyname = PyUnicode_FromString(charName);
             Py_DECREF(pyname);
         }
         Py_DECREF(attrClz); // parent class will hold the reference

--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -84,7 +84,7 @@ PyObject* PyJConstructor_New(JNIEnv *env, jobject constructor)
     pym->isStatic      = 1;
     pym->returnTypeId  = JOBJECT_ID;
     if (!initMethodName) {
-        initMethodName = PyString_FromString("<init>");
+        initMethodName = PyUnicode_FromString("<init>");
     }
     Py_INCREF(initMethodName);
     pym->pyMethodName = initMethodName;

--- a/src/main/c/Objects/pyjlist.c
+++ b/src/main/c/Objects/pyjlist.c
@@ -383,8 +383,8 @@ static PyObject* pyjlist_inplace_fill(PyObject *o, Py_ssize_t count)
 
 static PyObject* pyjlist_subscript(PyObject *self, PyObject *item)
 {
-    if (PyInt_Check(item)) {
-        long i = (long) PyInt_AS_LONG(item);
+    if (PyLong_Check(item)) {
+        long i = (long) PyLong_AsLongLong(item);
         if (i < 0) {
             i += (long) PyObject_Size(self);
         }
@@ -424,8 +424,8 @@ static PyObject* pyjlist_subscript(PyObject *self, PyObject *item)
 static int pyjlist_set_subscript(PyObject* self, PyObject* item,
                                  PyObject* value)
 {
-    if (PyInt_Check(item)) {
-        long i = (long) PyInt_AS_LONG(item);
+    if (PyLong_Check(item)) {
+        long i = (long) PyLong_AsLongLong(item);
         if (i < 0) {
             i += (long) PyObject_Size(self);
         }

--- a/src/main/c/Objects/pyjlist.c
+++ b/src/main/c/Objects/pyjlist.c
@@ -400,25 +400,11 @@ static PyObject* pyjlist_subscript(PyObject *self, PyObject *item)
         return pyjlist_getitem(self, (Py_ssize_t) i);
     } else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength;
-
-#if PY_MAJOR_VERSION >= 3
         if (PySlice_GetIndicesEx(item, PyObject_Size(self), &start, &stop, &step,
                                  &slicelength) < 0) {
             // error will already be set
             return NULL;
         }
-#else
-        /*
-         * This silences a compile warning on PySlice_GetIndicesEx by casting
-         * item.  Python fixed the method signature in 3.2 to take item as a
-         * PyObject*
-         */
-        if (PySlice_GetIndicesEx((PySliceObject *) item, PyObject_Size(self), &start,
-                                 &stop, &step, &slicelength) < 0) {
-            // error will already be set
-            return NULL;
-        }
-#endif
 
         if (slicelength <= 0) {
             return pyjlist_getslice(self, 0, 0);
@@ -455,25 +441,11 @@ static int pyjlist_set_subscript(PyObject* self, PyObject* item,
         return pyjlist_setitem(self, (Py_ssize_t) i, value);
     } else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength;
-
-#if PY_MAJOR_VERSION >= 3
         if (PySlice_GetIndicesEx(item, PyObject_Size(self), &start, &stop, &step,
                                  &slicelength) < 0) {
             // error will already be set
             return -1;
         }
-#else
-        /*
-         * This silences a compile warning on PySlice_GetIndicesEx by casting
-         * item.  Python fixed the method signature in 3.2 to take item as a
-         * PyObject*
-         */
-        if (PySlice_GetIndicesEx((PySliceObject *) item, PyObject_Size(self), &start,
-                                 &stop, &step, &slicelength) < 0) {
-            // error will already be set
-            return -1;
-        }
-#endif
 
         if (slicelength <= 0) {
             return 0;

--- a/src/main/c/Objects/pyjmap.c
+++ b/src/main/c/Objects/pyjmap.c
@@ -117,7 +117,7 @@ static PyObject* pyjmap_getitem(PyObject *o, PyObject *key)
             PyObject *pystr = PyObject_Str(key);
             PyErr_Format(PyExc_KeyError,
                          "KeyError: %s",
-                         PyString_AsString(pystr));
+                         PyUnicode_AsUTF8(pystr));
             Py_XDECREF(pystr);
             goto FINALLY;
         }
@@ -152,7 +152,7 @@ static int pyjmap_setitem(PyObject *o, PyObject *key, PyObject *v)
             PyObject *pystr = PyObject_Str(key);
             PyErr_Format(PyExc_KeyError,
                          "KeyError: %s",
-                         PyString_AsString(pystr));
+                         PyUnicode_AsUTF8(pystr));
             Py_XDECREF(pystr);
             goto FINALLY;
         }

--- a/src/main/c/Objects/pyjnumber.c
+++ b/src/main/c/Objects/pyjnumber.c
@@ -34,18 +34,6 @@ static PyObject* java_number_to_pythonintlong(JNIEnv *env, PyObject* n)
     jlong      value;
     PyJObject *jnumber  = (PyJObject*) n;
 
-#if PY_MAJOR_VERSION < 3
-    if ((*env)->IsInstanceOf(env, jnumber->object, JBYTE_OBJ_TYPE) ||
-            (*env)->IsInstanceOf(env, jnumber->object, JSHORT_OBJ_TYPE) ||
-            (*env)->IsInstanceOf(env, jnumber->object, JINT_OBJ_TYPE)) {
-        jint result = java_lang_Number_intValue(env, jnumber->object);
-        if (process_java_exception(env)) {
-            return NULL;
-        }
-        return PyInt_FromSsize_t(result);
-    }
-#endif
-
     value = java_lang_Number_longValue(env, jnumber->object);
     if (process_java_exception(env)) {
         return NULL;
@@ -134,17 +122,6 @@ static PyObject* pyjnumber_multiply(PyObject *x, PyObject *y)
     CALL_BINARY(env, PyNumber_Multiply, x, y);
     return result;
 }
-
-#if PY_MAJOR_VERSION < 3
-static PyObject* pyjnumber_divide(PyObject *x, PyObject *y)
-{
-    PyObject *result = NULL;
-    JNIEnv   *env    = pyembed_get_env();
-
-    CALL_BINARY(env, PyNumber_Divide, x, y);
-    return result;
-}
-#endif
 
 static PyObject* pyjnumber_remainder(PyObject *x, PyObject *y)
 {
@@ -257,13 +234,6 @@ static PyObject* pyjnumber_index(PyObject *x)
         Py_DECREF(x);
         return result;
     }
-#if PY_MAJOR_VERSION < 3
-    else if (PyInt_Check(x)) {
-        result = PyNumber_Index(x);
-        Py_DECREF(x);
-        return result;
-    }
-#endif
     else {
         PyErr_Format(PyExc_TypeError, "list indices must be integers, not %s",
                      Py_TYPE(x)->tp_name);
@@ -277,23 +247,6 @@ static PyObject* pyjnumber_int(PyObject *x)
     return java_number_to_pythonintlong(env, x);
 }
 
-#if PY_MAJOR_VERSION < 3
-static PyObject* pyjnumber_long(PyObject *x)
-{
-    PyObject *result = NULL;
-    JNIEnv   *env    = pyembed_get_env();
-
-    result = java_number_to_pythonintlong(env, x);
-    if (result == NULL) {
-        return result;
-    } else if (PyInt_Check(result)) {
-        PyObject *longResult = PyLong_FromLong(PyInt_AS_LONG(result));
-        Py_DECREF(result);
-        return longResult;
-    }
-    return result;
-}
-#endif
 
 static PyObject* pyjnumber_float(PyObject *x)
 {
@@ -338,9 +291,6 @@ static PyNumberMethods pyjnumber_number_methods = {
     (binaryfunc) pyjnumber_add,                 /* nb_add */
     (binaryfunc) pyjnumber_subtract,            /* nb_subtract */
     (binaryfunc) pyjnumber_multiply,            /* nb_multiply */
-#if PY_MAJOR_VERSION < 3
-    (binaryfunc) pyjnumber_divide,              /* nb_divide */
-#endif
     (binaryfunc) pyjnumber_remainder,           /* nb_remainder */
     (binaryfunc) pyjnumber_divmod,              /* nb_divmod */
     (ternaryfunc) pyjnumber_power,              /* nb_power */
@@ -354,26 +304,12 @@ static PyNumberMethods pyjnumber_number_methods = {
     0,                                          /* nb_and */
     0,                                          /* nb_xor */
     0,                                          /* nb_or */
-#if PY_MAJOR_VERSION < 3
-    0,                                          /* nb_coerce */
-#endif
     (unaryfunc) pyjnumber_int,                  /* nb_int */
-#if PY_MAJOR_VERSION < 3
-    (unaryfunc) pyjnumber_long,                 /* nb_long */
-#else
     0,                                          /* nb_reserved */
-#endif
     (unaryfunc) pyjnumber_float,                /* nb_float */
-#if PY_MAJOR_VERSION < 3
-    0,                                          /* nb_oct */
-    0,                                          /* nb_hex */
-#endif
     0,                                          /* inplace_add */
     0,                                          /* inplace_subtract */
     0,                                          /* inplace_multiply */
-#if PY_MAJOR_VERSION < 3
-    0,                                          /* inplace_divide */
-#endif
     0,                                          /* inplace_remainder */
     0,                                          /* inplace_power */
     0,                                          /* inplace_lshift */
@@ -412,11 +348,7 @@ PyTypeObject PyJNumber_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-#if PY_MAJOR_VERSION < 3
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES,/* tp_flags */
-#else
     Py_TPFLAGS_DEFAULT,                       /* tp_flags */
-#endif
     "jnumber",                                /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -133,7 +133,7 @@ static int pyjobject_init(JNIEnv *env, PyJObject *pyjob)
              * so, turn it into a PyJMultiMethod or add it to the existing
              * PyJMultiMethod.
              */
-            if (pymethod->pyMethodName && PyString_Check(pymethod->pyMethodName)) {
+            if (pymethod->pyMethodName && PyUnicode_Check(pymethod->pyMethodName)) {
                 PyObject* cached = PyDict_GetItem(cachedAttrs, pymethod->pyMethodName);
                 if (cached == NULL) {
                     if (PyDict_SetItem(cachedAttrs, pymethod->pyMethodName,
@@ -174,7 +174,7 @@ static int pyjobject_init(JNIEnv *env, PyJObject *pyjob)
                 continue;
             }
 
-            if (pyjfield->pyFieldName && PyString_Check(pyjfield->pyFieldName)) {
+            if (pyjfield->pyFieldName && PyUnicode_Check(pyjfield->pyFieldName)) {
                 if (PyDict_SetItem(cachedAttrs, pyjfield->pyFieldName,
                                    (PyObject*) pyjfield) != 0) {
                     goto EXIT_ERROR;
@@ -339,7 +339,7 @@ static PyObject* pyjobject_richcompare(PyJObject *self,
             jint result;
             jthrowable exc;
             if (!(*env)->IsInstanceOf(env, self->object, JCOMPARABLE_TYPE)) {
-                const char* jname = PyString_AsString(self->javaClassName);
+                const char* jname = PyUnicode_AsUTF8(self->javaClassName);
                 PyErr_Format(PyExc_TypeError, "Invalid comparison operation for Java type %s",
                              jname);
                 return NULL;
@@ -435,18 +435,18 @@ static int pyjobject_setattro(PyJObject *obj, PyObject *name, PyObject *v)
 
     if (cur == NULL) {
         PyErr_Format(PyExc_AttributeError, "'%s' object has no attribute '%s'.",
-                     PyString_AsString(obj->javaClassName), PyString_AsString(name));
+                     PyUnicode_AsUTF8(obj->javaClassName), PyUnicode_AsUTF8(name));
         return -1;
     }
 
     if (!PyJField_Check(cur)) {
         if (PyJMethod_Check(cur) || PyJMultiMethod_Check(cur)) {
             PyErr_Format(PyExc_AttributeError, "'%s' object cannot assign to method '%s'.",
-                         PyString_AsString(obj->javaClassName), PyString_AsString(name));
+                         PyUnicode_AsUTF8(obj->javaClassName), PyUnicode_AsUTF8(name));
         } else {
             PyErr_Format(PyExc_AttributeError,
                          "'%s' object cannot assign to attribute '%s'.",
-                         PyString_AsString(obj->javaClassName), PyString_AsString(name));
+                         PyUnicode_AsUTF8(obj->javaClassName), PyUnicode_AsUTF8(name));
         }
         return -1;
     }

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -337,10 +337,7 @@ static PyObject* pyjobject_richcompare(PyJObject *self,
              * raise a TypeError.
              */
             jint result;
-#if PY_MAJOR_VERSION >= 3
             jthrowable exc;
-#endif
-
             if (!(*env)->IsInstanceOf(env, self->object, JCOMPARABLE_TYPE)) {
                 const char* jname = PyString_AsString(self->javaClassName);
                 PyErr_Format(PyExc_TypeError, "Invalid comparison operation for Java type %s",
@@ -349,7 +346,6 @@ static PyObject* pyjobject_richcompare(PyJObject *self,
             }
 
             result = java_lang_Comparable_compareTo(env, target, other_target);
-#if PY_MAJOR_VERSION >= 3
             exc = (*env)->ExceptionOccurred(env);
             if (exc != NULL) {
                 if ((*env)->IsInstanceOf(env, exc, CLASSCAST_EXC_TYPE)) {
@@ -365,7 +361,6 @@ static PyObject* pyjobject_richcompare(PyJObject *self,
                     return Py_NotImplemented;
                 }
             }
-#endif
             if (process_java_exception(env)) {
                 return NULL;
             }
@@ -410,12 +405,7 @@ static PyObject* pyjobject_getattro(PyObject *obj, PyObject *name)
          * TODO Should not bind non-static methods to pyjclass objects, but not
          * sure yet how to handle multimethods and static methods.
          */
-#if PY_MAJOR_VERSION >= 3
         PyObject* wrapper = PyMethod_New(ret, (PyObject*) obj);
-#else
-        PyObject* wrapper = PyMethod_New(ret, (PyObject*) obj,
-                                         (PyObject*) Py_TYPE(obj));
-#endif
         Py_DECREF(ret);
         return wrapper;
     } else if (PyJField_Check(ret)) {


### PR DESCRIPTION
This pull request removes all #if PY_MAJOR_VERSION checks, so Python3+ is the only supported version. Furthermore this leads to cleaner code. Removing the support for Python 2 was proposed in #202 