### PR TITLE
Don't use PyUnicode_GET_SIZE in Python 3.

### DIFF
--- a/src/main/c/Jep/jep_util.c
+++ b/src/main/c/Jep/jep_util.c
@@ -474,9 +474,15 @@ int pyarg_matches_jtype(JNIEnv *env,
             return 3;
             break;
         case JCHAR_ID:
+#if PY_MAJOR_VERSION < 3
             if (PyUnicode_GET_SIZE(param) == 1) {
                 return 2;
             }
+#else
+            if (PyUnicode_GET_LENGTH(param) == 1) {
+                return 2;
+            }
+#endif
             break;
         case JOBJECT_ID:
             if ((*env)->IsAssignableFrom(env, JSTRING_TYPE, paramType)) {


### PR DESCRIPTION
It is a deprecated API.  Use PyUnicode_GET_LENGTH instead.