### PR TITLE
Don't use PyUnicode_GET_SIZE

### DIFF
--- a/src/main/c/Jep/jep_util.c
+++ b/src/main/c/Jep/jep_util.c
@@ -474,7 +474,7 @@ int pyarg_matches_jtype(JNIEnv *env,
             return 3;
             break;
         case JCHAR_ID:
-            if (PyUnicode_GET_SIZE(param) == 1) {
+            if (PyUnicode_GET_LENGTH(param) == 1) {
                 return 2;
             }
             break;


### PR DESCRIPTION
PyUnicode_GET_SIZE is deprecated since Python 3.3