### PR TITLE
docs: fix simple typo, copyied -> copied

### DIFF
--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -1634,7 +1634,7 @@ EXIT:
 }
 
 
-// gratuitously copyied from pythonrun.c::run_pyc_file
+// gratuitously copied from pythonrun.c::run_pyc_file
 static void pyembed_run_pyc(JepThread *jepThread,
                             FILE *fp)
 {
@@ -1678,7 +1678,7 @@ static void pyembed_run_pyc(JepThread *jepThread,
 
 /* Check whether a file maybe a pyc file: Look at the extension,
  the file type, and, if we may close it, at the first few bytes. */
-// gratuitously copyied from pythonrun.c::run_pyc_file
+// gratuitously copied from pythonrun.c::run_pyc_file
 static int maybe_pyc_file(FILE *fp, const char* filename, const char* ext,
                           int closeit)
 {


### PR DESCRIPTION
There is a small typo in src/main/c/Jep/pyembed.c.

Should read `copied` rather than `copyied`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md