### PR TITLE
Search site packages for Mac framework builds

### DIFF
--- a/src/main/java/jep/LibraryLocator.java
+++ b/src/main/java/jep/LibraryLocator.java
@@ -193,6 +193,32 @@ final class LibraryLocator {
             }
 
         }
+        
+        // For Mac framework builds
+        if (userHome != null) {
+            File localDir = new File(userHome, "Library");
+            if (localDir.isDirectory()) {
+                File pythonMainDir = new File(localDir, "Python");
+                if (pythonMainDir.isDirectory()) {
+                    for (File versionDir : pythonMainDir.listFiles()) {
+                        if (versionDir.isDirectory() && versionDir.getName().matches("\\d\\.\\d")) {
+                            File libDir = new File(versionDir, "lib");
+                            if (libDir.isDirectory()) {
+                                File pythonDir = new File(libDir, "python");
+                                if (pythonDir.isDirectory()) {
+                                    File packagesDir = new File(pythonDir, "site-packages");
+                                    if (searchPackageDir(packagesDir)) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+        
         return false;
     }
 


### PR DESCRIPTION
Thanks for this package.

I noticed that Jep does not search user site-packages for python framework builds, which leads to an Unsatisfied Link error. 

Using this fix would solve the issue.
