### PR TITLE
Support string type codes for pyjarray creation.

### DIFF
--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -154,15 +154,14 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             handle_startup_exception(env, "Couldn't set _jep on sys.modules");
             return -1;
         }
-        PyModule_AddIntConstant(modjep, "JBOOLEAN_ID", JBOOLEAN_ID);
-        PyModule_AddIntConstant(modjep, "JINT_ID", JINT_ID);
-        PyModule_AddIntConstant(modjep, "JLONG_ID", JLONG_ID);
-        PyModule_AddIntConstant(modjep, "JSTRING_ID", JSTRING_ID);
-        PyModule_AddIntConstant(modjep, "JDOUBLE_ID", JDOUBLE_ID);
-        PyModule_AddIntConstant(modjep, "JSHORT_ID", JSHORT_ID);
-        PyModule_AddIntConstant(modjep, "JFLOAT_ID", JFLOAT_ID);
-        PyModule_AddIntConstant(modjep, "JCHAR_ID", JCHAR_ID);
-        PyModule_AddIntConstant(modjep, "JBYTE_ID", JBYTE_ID);
+        PyModule_AddStringConstant(modjep, "JBOOLEAN_ID", "z");
+        PyModule_AddStringConstant(modjep, "JINT_ID", "i");
+        PyModule_AddStringConstant(modjep, "JLONG_ID", "j");
+        PyModule_AddStringConstant(modjep, "JDOUBLE_ID", "d");
+        PyModule_AddStringConstant(modjep, "JSHORT_ID", "s");
+        PyModule_AddStringConstant(modjep, "JFLOAT_ID", "f");
+        PyModule_AddStringConstant(modjep, "JCHAR_ID", "c");
+        PyModule_AddStringConstant(modjep, "JBYTE_ID", "b");
         PyModule_AddIntConstant(modjep, "JEP_NUMPY_ENABLED", JEP_NUMPY_ENABLED);
         PyObject *javaAttrCache = PyDict_New();
         if (!javaAttrCache) {
@@ -184,6 +183,17 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             Py_DECREF(modjep);
             return -1;
         }
+	/* JSTRING_ID ust be done after the caches */
+	PyObject* stringClass = PyJClass_Wrap(env, JSTRING_TYPE);
+	if (!stringClass) {
+            Py_DECREF(modjep);
+            return -1;
+	}
+        if (PyModule_AddObject(modjep, "JSTRING_ID", stringClass)) {
+            Py_DECREF(stringClass);
+            Py_DECREF(modjep);
+            return -1;
+	}
         if (hasSharedModules) {
             Py_INCREF(mainThreadModules);
             PyModule_AddObject(modjep, "mainInterpreterModules", mainThreadModules);

--- a/src/test/python/test_array.py
+++ b/src/test/python/test_array.py
@@ -1,6 +1,16 @@
 import os
 import unittest
-from jep import jarray, JINT_ID, JBYTE_ID
+
+from jep import jarray
+from jep import JBOOLEAN_ID, JCHAR_ID
+from jep import JBYTE_ID, JSHORT_ID, JINT_ID, JLONG_ID
+from jep import JFLOAT_ID, JDOUBLE_ID
+
+from java.util import Arrays
+from java.lang.reflect import Array
+from java.lang import Boolean, Character
+from java.lang import Byte, Short, Integer, Long
+from java.lang import Float, Double
 
 
 class TestArray(unittest.TestCase):
@@ -134,3 +144,51 @@ class TestArray(unittest.TestCase):
     def test_jarray_one_arg_throws_exception(self):
         with self.assertRaises(Exception):
             jep.jarray(1)
+
+    def test_primitive_bool_array_creation(self):
+        base = Array.newInstance(Boolean.TYPE, 1);
+        self.assertTrue(base, jarray(1, JBOOLEAN_ID))
+        self.assertTrue(base, jarray(1, 'z'))
+        self.assertTrue(base, jarray(1, Boolean.TYPE))
+
+    def test_primitive_byte_array_creation(self):
+        base = Array.newInstance(Byte.TYPE, 1);
+        self.assertTrue(base, jarray(1, JBYTE_ID))
+        self.assertTrue(base, jarray(1, 'b'))
+        self.assertTrue(base, jarray(1, Byte.TYPE))
+
+    def test_primitive_char_array_creation(self):
+        base = Array.newInstance(Character.TYPE, 1);
+        self.assertTrue(base, jarray(1, JCHAR_ID))
+        self.assertTrue(base, jarray(1, 'c'))
+        self.assertTrue(base, jarray(1, Character.TYPE))
+
+    def test_primitive_short_array_creation(self):
+        base = Array.newInstance(Short.TYPE, 1);
+        self.assertTrue(base, jarray(1, JSHORT_ID))
+        self.assertTrue(base, jarray(1, 's'))
+        self.assertTrue(base, jarray(1, Short.TYPE))
+
+    def test_primitive_int_array_creation(self):
+        base = Array.newInstance(Integer.TYPE, 1);
+        self.assertTrue(base, jarray(1, JINT_ID))
+        self.assertTrue(base, jarray(1, 'i'))
+        self.assertTrue(base, jarray(1, Integer.TYPE))
+
+    def test_primitive_long_array_creation(self):
+        base = Array.newInstance(Long.TYPE, 1);
+        self.assertTrue(base, jarray(1, JLONG_ID))
+        self.assertTrue(base, jarray(1, 'j'))
+        self.assertTrue(base, jarray(1, Long.TYPE))
+
+    def test_primitive_float_array_creation(self):
+        base = Array.newInstance(Float.TYPE, 1);
+        self.assertTrue(base, jarray(1, JFLOAT_ID))
+        self.assertTrue(base, jarray(1, 'f'))
+        self.assertTrue(base, jarray(1, Float.TYPE))
+
+    def test_primitive_double_array_creation(self):
+        base = Array.newInstance(Double.TYPE, 1);
+        self.assertTrue(base, jarray(1, JDOUBLE_ID))
+        self.assertTrue(base, jarray(1, 'd'))
+        self.assertTrue(base, jarray(1, Double.TYPE))


### PR DESCRIPTION
I like the way that the [python array module](https://docs.python.org/3/library/array.html) uses simple one character type codes for specifying the array type and I would like to have similar support for jarray construction. Currently primitive jarrays must be created using the J*_ID constants defined in the jep module. It would be convenient to use the same type codes as the python array module but I ran into some problems

1) There is no character for boolean
2) The character that makes sense for char is 'u' but that is deprecated
3) I think we would use 'l' for java int and 'q' for java long and I'm not sure what we could do with 'i'. I think 'l' for int would confuse java developers.

Numpy also has support for [similar typestrs](https://numpy.org/doc/stable/reference/arrays.interface.html) but since they encode the length of the type that is harder to parse and I feel like it is less intuitive especially since we only support a very small set of types compared to numpy. I settled on the [JNI type characters](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/types.html#type-signatures) in lowercase(z, b, c, s, i, j, f or d). This perfectly matches the types we support. There still may be some confusion since 'j' is used for long but I would rather defer to an existing "standard" instead of come up with our own system.

I want to continue to support jep.J*_ID from python for backwards compatibility but I want the public API to reflect that we are supporting type codes instead of ints for these so I switched them to the type codes.

jep.JSTRING_ID does not have a type code, I think we should drop that field at some point and encourage developers to just import and use java.lang.String. For for this change I chose to preserve backwards compatibility so I made JSTRING_ID the pyjclass for java.lang.String

Another problem with this change is that the c code has J*_ID constant that no longer match the python constants. These constants cannot be strings because they are used in switch statements. Eventually I think they should be changed to the char/ascii/unicode values for the type code but for this change I left the existing values. Since they are only used internally there is no user facing impact except if there is any case where developers have hardcoded the numerical constant it will still work now.

While testing I notices that passing a primitive class, such as java.lang.Integer.TYPE, into jarray would crash, so I made code to handle that case and return a primitive array. Perhaps JINT_ID should be set to java.lang.Integer.TYPE instead of a type code? I like the type code more.

Below is a summary of the major design decisions in this change. I'd appreciate input to see if others have different opinions on any of these.

1) Should we support types codes?
 * Yes
2) Which typecodes?
 * JNI specification (z, b, c, s, i, j, f or d).
3) What should we use for the values of the primitive jep.J*_ID constants
 * Changed from ints to type codes(String).
4) What about jep.JSTRING_ID?
 * JSTRING_ID will be a pyjclass for java.util.String, the same valyue you would get with `from java.lang import String`
5) What backwards compatibilty features will remain now but be removed in the future.
 * Change internal c constants for J*ID for primitive to be the char/ascii/unicode value matching the python char and remove support for passing int values to jep.jarray. This will only affect users who hardcoded the old int values.
 * Remove jep.JSTRING_ID, developers who are using it would have to switch to `from java.lang import String`
6) When should those backwards compatibiltiy features be removed.
 * TBD I would be fine with removing them in 4.1 but if they aren't causing trouble they may last longer.
