### PR TITLE
Add __repr__ support for pyjobject. If method defined on java class, …

### DIFF
--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -272,6 +272,45 @@ static PyObject* pyjobject_str(PyJObject *self)
     return pyres;
 }
 
+// call __repr__() on jobject. returns null on error.
+// expected to return new reference.
+static PyObject* pyjobject_repr(PyJObject *self)
+{
+    PyObject   *pyres   = NULL;
+    JNIEnv     *env;
+    jmethodID  __repr__ = 0;
+    jstring    jrepr    = NULL;
+
+    //check if __repr__ method exists on java object
+    if (self->object && self->clazz) {
+        env   = pyembed_get_env();
+
+        Py_BEGIN_ALLOW_THREADS
+        if (JNI_METHOD(__repr__, env, self->clazz, "__repr__", "()Ljava/lang/String;")) {
+            jrepr = (jstring) (*env)->CallObjectMethod(env, self->object, __repr__);
+        } else {
+            //method does not exist, clear exception
+            if ((*env)->ExceptionCheck(env)) {
+                (*env)->ExceptionClear(env);
+            }
+        }
+        Py_END_ALLOW_THREADS
+        if (process_java_exception(env)) {
+            return NULL;
+        }
+        if (jrepr != NULL) {
+            pyres = jstring_As_PyString(env, jrepr);
+        }
+        (*env)->DeleteLocalRef(env, jrepr);
+    }
+
+    if (pyres == NULL) {
+        //default (see: PyObject_Repr)
+        pyres =  PyUnicode_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, self);
+    }
+    return pyres;
+}
+
 
 static PyObject* pyjobject_richcompare(PyJObject *self,
                                        PyObject *_other,
@@ -537,7 +576,7 @@ PyTypeObject PyJObject_Type = {
     0,                                        /* tp_getattr */
     0,                                        /* tp_setattr */
     0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
+    (reprfunc) pyjobject_repr,                /* tp_repr */
     0,                                        /* tp_as_number */
     0,                                        /* tp_as_sequence */
     0,                                        /* tp_as_mapping */

--- a/src/test/java/jep/test/TestPyJObject.java
+++ b/src/test/java/jep/test/TestPyJObject.java
@@ -1,0 +1,17 @@
+package jep.test;
+
+/**
+ * Supporting test_object.py
+ */
+public class TestPyJObject {
+
+    public static class ReprClass {
+        public String __repr__() {
+            return getClass().getSimpleName();
+        }
+    }
+
+    public static class ReprSubClass extends ReprClass {
+    }
+
+}

--- a/src/test/python/test_object.py
+++ b/src/test/python/test_object.py
@@ -1,6 +1,8 @@
 import unittest
 from java.lang import Object
+import jep
 
+TestPyJObject = jep.findClass('jep.test.TestPyJObject')
 
 class TestObject(unittest.TestCase):
 
@@ -11,6 +13,11 @@ class TestObject(unittest.TestCase):
     def test_str(self):
         o = Object()
         self.assertIn('java.lang.Object@', str(o))
+
+    def test_repr(self):
+        self.assertEquals(repr(TestPyJObject.ReprClass()), "ReprClass")
+        self.assertEquals(repr(TestPyJObject.ReprSubClass()), "ReprSubClass")
+        self.assertIn("<jep.PyJObject object at", repr(Object()))
 
     def test_del_throws_exception(self):
         o = Object()


### PR DESCRIPTION
…it will be picked up for tp_repr of the python wrapper.

Hey, this is some suggestion for supporting custom __repr__ implementations in jep according to the discussion in https://github.com/ninia/jep/issues/330
Please review carefully, especially with regards to memory management in C ;)

For the test, I found test_object.py to be a good place, as it is also testing hash and toString, but I'm not sure about the naming conventions here (might be only meant for the Object class). I needed two simple java test classes (implementing __repr__), but none of the existing java Test* classes sounded like the right place for them, so I added TestPyJObject. 

@bsteffensmeier 
I'm not sure about performance, do you see this method as performance critical? I saw in jep 4.0 you are creating dedicated py types for all java classes https://github.com/ninia/jep/commit/151c748f6c3674bc1ef292156fa82224a208fa3c
Would this be a better place?


