### PR TITLE
Allow empty kwargs in calls to PyObjects

### DIFF
--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -123,7 +123,7 @@ static PyObject* pyjconstructor_call(PyJMethodObject *self, PyObject *args,
     jobject   obj  = NULL;
     PyObject *pobj = NULL;
 
-    if (keywords != NULL) {
+    if (keywords != NULL && PyDict_Size(keywords) > 0) {
         PyErr_Format(PyExc_TypeError, "Keywords are not supported.");
         return NULL;
     }

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -221,7 +221,7 @@ static PyObject* pyjmethod_call(PyJMethodObject *self,
     /* if params includes pyjarray instance */
     int            foundArray       = 0;
 
-    if (keywords != NULL) {
+    if (keywords != NULL && PyDict_Size(keywords) > 0) {
         PyErr_Format(PyExc_RuntimeError, "Keywords are not supported.");
         return NULL;
     }

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -116,7 +116,7 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
     Py_ssize_t        argsSize       = 0;
     JNIEnv*           env            = NULL;
 
-    if (keywords != NULL) {
+    if (keywords != NULL && PyDict_Size(keywords) > 0) {
         PyErr_Format(PyExc_RuntimeError, "Keywords are not supported.");
         return NULL;
     }


### PR DESCRIPTION
Python libraries expect to be able to wrap arbitrary functions and call them later by passing in `*args` and `**kwargs`.

See the [`functools.wraps`](https://docs.python.org/3/library/functools.html#functools.wraps) example code, or the rather popular [`tqdm` library](https://github.com/tqdm/tqdm/blob/fc69d5dcf578f7c7986fa76841a6b793f813df35/tqdm/utils.py#L132).

Unfortunately, attempting this with a PyObject leads to a "Keywords are not supported." error.

Here's a (very) silly example using the `DisableOnWriteError` wrapper from `tqdm`:

```
$ jep
>>> import tqdm
>>> from java.lang import System
>>> from tqdm.utils import DisableOnWriteError
>>> x = DisableOnWriteError(System.out, None)
>>> x.write(1)
Keywords are not supported.
```

This PR allows invocation with empty kwargs to pass without raising an error.