### PR TITLE
Implement `isatty` method in StreamRedirect

### DIFF
--- a/src/main/python/jep/redirect_streams.py
+++ b/src/main/python/jep/redirect_streams.py
@@ -40,6 +40,9 @@ class StreamRedirect(object):
     def flush(self):
         self.flushmethod()
 
+    def isatty(self):
+        return False
+
 def redirectStdout(javaOutputStream):
     sys.stdout = StreamRedirect(javaOutputStream)
 


### PR DESCRIPTION
The [`isatty()`](https://docs.python.org/3/library/io.html#io.IOBase.isatty) function can be used to check whether a file object is interactive.

By default, `sys.stdout` and `sys.stderr` implement this method, so some Python libraries assume it will always be present and call `sys.stdout.isatty()` without checking to see whether it's implemented.

Technically, at least as far as I am able to tell, there is no strict definition of what a Python "file object" is, so callers should really be checking whether the out file in question has the `isatty` attribute. Unfortunately, they often don't.

We ran into this issue [in Polynote](https://github.com/polynote/polynote/issues/696) and implemented `isatty` in our own wrapper. I figured it makes sense to implement it in your wrapper as well.