### PR TITLE
Java import hook uses newer import hook API

### DIFF
--- a/src/main/python/jep/java_import_hook.py
+++ b/src/main/python/jep/java_import_hook.py
@@ -80,7 +80,6 @@ def makeModule(fullname, loader, classEnquirer):
         '__package__': None,
         '__classEnquirer__': classEnquirer,
     })
-    sys.modules[fullname] = mod
     return mod
 
 
@@ -99,9 +98,6 @@ class JepJavaImporter(object):
 
     def create_module(self, spec):
         fullname = spec.name
-        if fullname in sys.modules:
-            return sys.modules[fullname]
-
         mod = makeModule(fullname, self, self.classEnquirer)
         return mod
 

--- a/src/main/python/jep/java_import_hook.py
+++ b/src/main/python/jep/java_import_hook.py
@@ -26,7 +26,7 @@
 from _jep import forName
 import sys
 from types import ModuleType
-from importlib.machinery import ModuleSpec
+from importlib.util import spec_from_loader
 
 class module(ModuleType):
     """Lazy load classes not found at runtime.
@@ -94,7 +94,7 @@ class JepJavaImporter(object):
 
     def find_spec(self, fullname, path, target=None):
         if self.classEnquirer.isJavaPackage(fullname):
-            return ModuleSpec(fullname, self, is_package=True)
+            return spec_from_loader(fullname, self, is_package=True)
         return None
 
     def create_module(self, spec):

--- a/src/main/python/jep/java_import_hook.py
+++ b/src/main/python/jep/java_import_hook.py
@@ -26,7 +26,7 @@
 from _jep import forName
 import sys
 from types import ModuleType
-
+from importlib.machinery import ModuleSpec
 
 class module(ModuleType):
     """Lazy load classes not found at runtime.
@@ -92,17 +92,21 @@ class JepJavaImporter(object):
         else:
             self.classEnquirer = forName('jep.ClassList').getInstance()
 
-    def find_module(self, fullname, path=None):
+    def find_spec(self, fullname, path, target=None):
         if self.classEnquirer.isJavaPackage(fullname):
-            return self  # found a Java package with this name
+            return ModuleSpec(fullname, self, is_package=True)
         return None
 
-    def load_module(self, fullname):
+    def create_module(self, spec):
+        fullname = spec.name
         if fullname in sys.modules:
             return sys.modules[fullname]
 
         mod = makeModule(fullname, self, self.classEnquirer)
         return mod
+
+    def exec_module(self, fullname):
+        return None
 
 
 def setupImporter(classEnquirer):

--- a/src/test/python/test_import.py
+++ b/src/test/python/test_import.py
@@ -17,7 +17,8 @@ class TestImport(unittest.TestCase):
 
     def test_not_found(self):
         importer = JepJavaImporter()
-        mod = importer.load_module('java.lang')
+        spec = importer.find_spec('java.lang', None)
+        mod = importer.create_module(spec)
         mod.Integer
         self.assertRaises(ImportError, mod.__getattr__, 'asdf')
 


### PR DESCRIPTION
This updates the java import hook to use the newer import hook API.  This fixes part of #356.  Note I did not update the shared modules import hook.