### PR TITLE
Fix export syntax on generated jep script

### DIFF
--- a/commands/scripts.py
+++ b/commands/scripts.py
@@ -79,7 +79,7 @@ class build_scripts(Command):
             if is_osx():
                 # OS X is setting sys.executable to java which is preventing it from finding site-packages in a venv
                 # setting PYTHONEXECUTABLE overrides sys.executable and helps find site-packages
-                context['pythonexecutable'] = 'export PYTHONEXECUTABLE = %s' % sys.executable
+                context['pythonexecutable'] = 'export PYTHONEXECUTABLE="%s"' % sys.executable
 
 
         if not is_osx() and not is_windows():


### PR DESCRIPTION
This PR fixes shell syntax of the generated `jep` binary.

Shell does not like blanks around the "=".  Also, it seems appropriate
to quote the path in case of paths with blanks.

Fixes #383.
See also #382.
