### PR TITLE
Change Java fields and methods to type attributes instead of instance attributes

### DIFF
--- a/src/main/c/Include/java_access/Class.h
+++ b/src/main/c/Include/java_access/Class.h
@@ -31,6 +31,8 @@
 jclass       java_lang_Class_getComponentType(JNIEnv*, jclass);
 jobjectArray java_lang_Class_getConstructors(JNIEnv*, jclass);
 jobjectArray java_lang_Class_getDeclaredClasses(JNIEnv*, jclass);
+jobjectArray java_lang_Class_getDeclaredFields(JNIEnv*, jclass);
+jobjectArray java_lang_Class_getDeclaredMethods(JNIEnv*, jclass);
 jobjectArray java_lang_Class_getFields(JNIEnv*, jclass);
 jobjectArray java_lang_Class_getMethods(JNIEnv*, jclass);
 jint         java_lang_Class_getModifiers(JNIEnv*, jclass);

--- a/src/main/c/Include/pyjclass.h
+++ b/src/main/c/Include/pyjclass.h
@@ -45,7 +45,9 @@ typedef struct {
      * A python callable, either a PyJConstructor or PyJMultiMethod with many
      * PyJConstructors
      */
-    PyObject  *constructor;
+    PyObject *constructor;
+    /* A python dict containing fields, methods, and inner classes */
+    PyObject *attr;
 } PyJClassObject;
 
 PyObject* PyJClass_Wrap(JNIEnv*, jobject);

--- a/src/main/c/Include/pyjobject.h
+++ b/src/main/c/Include/pyjobject.h
@@ -46,7 +46,6 @@ extern PyTypeObject PyJObject_Type;
 #define PyJObject_FIELDS \
     jobject   object;    \
     jclass    clazz;     \
-    PyObject *attr;      \
     PyObject *javaClassName;
 
 typedef struct {

--- a/src/main/c/Jep/java_access/Class.c
+++ b/src/main/c/Jep/java_access/Class.c
@@ -30,6 +30,8 @@
 static jmethodID getComponentType   = 0;
 static jmethodID getConstructors    = 0;
 static jmethodID getDeclaredClasses = 0;
+static jmethodID getDeclaredFields  = 0;
+static jmethodID getDeclaredMethods = 0;
 static jmethodID getFields          = 0;
 static jmethodID getMethods         = 0;
 static jmethodID getModifiers       = 0;
@@ -72,6 +74,30 @@ jobjectArray java_lang_Class_getDeclaredClasses(JNIEnv* env, jclass this)
     if (JNI_METHOD(getDeclaredClasses, env, JCLASS_TYPE, "getDeclaredClasses",
                    "()[Ljava/lang/Class;")) {
         result = (jobjectArray) (*env)->CallObjectMethod(env, this, getDeclaredClasses);
+    }
+    Py_END_ALLOW_THREADS
+    return result;
+}
+
+jobjectArray java_lang_Class_getDeclaredFields(JNIEnv* env, jclass this)
+{
+    jobjectArray result = NULL;
+    Py_BEGIN_ALLOW_THREADS
+    if (JNI_METHOD(getDeclaredFields, env, JCLASS_TYPE, "getDeclaredFields",
+                   "()[Ljava/lang/reflect/Field;")) {
+        result = (jobjectArray) (*env)->CallObjectMethod(env, this, getDeclaredFields);
+    }
+    Py_END_ALLOW_THREADS
+    return result;
+}
+
+jobjectArray java_lang_Class_getDeclaredMethods(JNIEnv* env, jclass this)
+{
+    jobjectArray result = NULL;
+    Py_BEGIN_ALLOW_THREADS
+    if (JNI_METHOD(getDeclaredMethods, env, JCLASS_TYPE, "getDeclaredMethods",
+                   "()[Ljava/lang/reflect/Method;")) {
+        result = (jobjectArray) (*env)->CallObjectMethod(env, this, getDeclaredMethods);
     }
     Py_END_ALLOW_THREADS
     return result;

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -182,11 +182,6 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             Py_DECREF(modjep);
             return -1;
         }
-        if (PyModule_AddObject(modjep, "__javaAttributeCache__", javaAttrCache)) {
-            Py_DECREF(javaAttrCache);
-            Py_DECREF(modjep);
-            return -1;
-        }
         PyObject *javaTypeCache = PyDict_New();
         if (!javaTypeCache) {
             Py_DECREF(modjep);

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -177,11 +177,6 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
         PyModule_AddStringConstant(modjep, "JCHAR_ID", "c");
         PyModule_AddStringConstant(modjep, "JBYTE_ID", "b");
         PyModule_AddIntConstant(modjep, "JEP_NUMPY_ENABLED", JEP_NUMPY_ENABLED);
-        PyObject *javaAttrCache = PyDict_New();
-        if (!javaAttrCache) {
-            Py_DECREF(modjep);
-            return -1;
-        }
         PyObject *javaTypeCache = PyDict_New();
         if (!javaTypeCache) {
             Py_DECREF(modjep);

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -141,6 +141,10 @@ static PyObject* pyjclass_add_inner_classes(JNIEnv *env,
  * class. This is currently the only way static methods and fields are made
  * available. There is no known use for non-static fields but for now they are
  * left in for backwards compatiblity, consider removing them in the future.
+ *
+ * Since the method and fields for a class are added to the type and the type
+ * is cached, this can just copy the attributes from he type and avoid any
+ * reflection.
  */
 static PyObject* pyjclass_init_attr(JNIEnv *env, jclass clazz)
 {

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -143,7 +143,7 @@ static PyObject* pyjclass_add_inner_classes(JNIEnv *env,
  * left in for backwards compatiblity, consider removing them in the future.
  *
  * Since the method and fields for a class are added to the type and the type
- * is cached, this can just copy the attributes from he type and avoid any
+ * is cached, this can just copy the attributes from the type and avoid any
  * reflection.
  */
 static PyObject* pyjclass_init_attr(JNIEnv *env, jclass clazz)

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -613,6 +613,39 @@ int pyjfield_set(PyJFieldObject *self, PyJObject* pyjobject, PyObject *value)
     return -1;
 }
 
+static PyObject* pyjfield_descr_get(PyObject *field, PyObject *obj,
+                                    PyObject *type)
+{
+    if (obj == Py_None || obj == NULL) {
+        Py_INCREF(field);
+        return field;
+    } else if (PyJObject_Check(obj)) {
+        return pyjfield_get((PyJFieldObject*) field, (PyJObject*) obj);
+    } else {
+        PyErr_Format(PyExc_RuntimeError,
+                     "PyJField can only access fields on Java objects");
+        return NULL;
+    }
+}
+
+
+static int pyjfield_descr_set(PyObject *field, PyObject *obj, PyObject *value)
+{
+    if (value == NULL) {
+        PyErr_Format(PyExc_TypeError,
+                     "Deleting Java fields is not allowed");
+        return -1;
+    }
+
+    if (PyJObject_Check(obj)) {
+        return pyjfield_set((PyJFieldObject*) field, (PyJObject*) obj, value);
+    } else {
+        PyErr_Format(PyExc_RuntimeError,
+                     "PyJField can only access fields on Java objects");
+        return -1;
+    }
+}
+
 
 PyTypeObject PyJField_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -647,8 +680,8 @@ PyTypeObject PyJField_Type = {
     0,                                        /* tp_getset */
     0,                                        /* tp_base */
     0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
+    pyjfield_descr_get,                       /* tp_descr_get */
+    pyjfield_descr_set,                       /* tp_descr_set */
     0,                                        /* tp_dictoffset */
     0,                                        /* tp_init */
     0,                                        /* tp_alloc */

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -776,6 +776,16 @@ EXIT_ERROR:
     return NULL;
 }
 
+static PyObject* pyjmethod_descr_get(PyObject *func, PyObject *obj,
+                                     PyObject *type)
+{
+    if (obj == Py_None || obj == NULL) {
+        Py_INCREF(func);
+        return func;
+    }
+    return PyMethod_New(func, obj);
+}
+
 static PyMemberDef pyjmethod_members[] = {
     {
         "__name__", T_OBJECT_EX, offsetof(PyJMethodObject, pyMethodName), READONLY,
@@ -818,7 +828,7 @@ PyTypeObject PyJMethod_Type = {
     0,                                        /* tp_getset */
     0,                                        /* tp_base */
     0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
+    pyjmethod_descr_get,                      /* tp_descr_get */
     0,                                        /* tp_descr_set */
     0,                                        /* tp_dictoffset */
     0,                                        /* tp_init */

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -193,6 +193,16 @@ static void pyjmultimethod_dealloc(PyJMultiMethodObject *self)
     PyObject_Del(self);
 }
 
+static PyObject* pyjmultimethod_descr_get(PyObject *func, PyObject *obj,
+        PyObject *type)
+{
+    if (obj == Py_None || obj == NULL) {
+        Py_INCREF(func);
+        return func;
+    }
+    return PyMethod_New(func, obj);
+}
+
 static PyGetSetDef pyjmultimethod_getsetlist[] = {
     {"__name__", (getter) PyJMultiMethod_GetName, NULL},
     {"__methods__", (getter) pyjmultimethod_getmethods, NULL},
@@ -236,7 +246,7 @@ PyTypeObject PyJMultiMethod_Type = {
     pyjmultimethod_getsetlist,                /* tp_getset */
     0,                                        /* tp_base */
     0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
+    pyjmultimethod_descr_get,                 /* tp_descr_get */
     0,                                        /* tp_descr_set */
     0,                                        /* tp_dictoffset */
     0,                                        /* tp_init */

--- a/src/main/c/Objects/pyjtype.c
+++ b/src/main/c/Objects/pyjtype.c
@@ -184,7 +184,8 @@ static PyObject* getBaseTypes(JNIEnv *env, PyObject *fqnToPyType, jclass clazz)
 
 /*
  * Adding empty slots to the type dict to prevent creation of __dict__ for
- * every instance and ensures all attributes go through pyjfield.
+ * every instance and ensures all attribute access goes through the original
+ * Java object using pyjfield, pyjmethod or pyjmultimethod.
  */
 static int addSlots(PyObject* dict)
 {

--- a/src/test/java/jep/test/TestPyJObject.java
+++ b/src/test/java/jep/test/TestPyJObject.java
@@ -14,4 +14,9 @@ public class TestPyJObject {
     public static class ReprSubClass extends ReprClass {
     }
 
+    public static class AddClass {
+        public int __add__(int value) {
+            return value + 1;
+        }
+    }
 }

--- a/src/test/python/test_object.py
+++ b/src/test/python/test_object.py
@@ -1,5 +1,6 @@
 import unittest
 from java.lang import Object
+from java.util import ArrayList
 import jep
 
 TestPyJObject = jep.findClass('jep.test.TestPyJObject')
@@ -14,15 +15,30 @@ class TestObject(unittest.TestCase):
         o = Object()
         self.assertIn('java.lang.Object@', str(o))
 
+    def test_toString(self):
+        o = Object()
+        self.assertIn('java.lang.Object@', o.toString())
+
     def test_repr(self):
         self.assertEquals(repr(TestPyJObject.ReprClass()), "ReprClass")
         self.assertEquals(repr(TestPyJObject.ReprSubClass()), "ReprSubClass")
         self.assertIn("<java.lang.Object object at", repr(Object()))
 
+    def test_add(self):
+        self.assertEquals(TestPyJObject.AddClass() + 6, 7)
+
     def test_del_throws_exception(self):
         o = Object()
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             del o.equals
+        with self.assertRaises(AttributeError):
+            o.bad = 7
+        # Subtypes can behave differently then base types so also check a subtype
+        o = ArrayList()
+        with self.assertRaises(AttributeError):
+            del o.add
+        with self.assertRaises(AttributeError):
+            o.bad = 7
 
     def test_java_name(self):
         self.assertEquals(Object.java_name, "java.lang.Object")


### PR DESCRIPTION
The relationship between PyJObjects and their types now more closely resembles
the behavior of normal Python types, allowing special methods such as __add__
and __repr__ to be picked up by Python when they are defined in Java classes.

Since all attributes of PyJObject have moved to the type the attr dict is no
longer necessary. However, every instance of PyJClass still shares a type so it
is not possible to move attributes of PyJClass to the type. Much of the code
for dealing with instance attributes has moved from PyJObject to PyJClass.