### PR TITLE
Improve libpython detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from commands.install_lib import jep_install
 from commands.java import build_java, get_java_home, get_java_include,\
     get_java_linker_args, build_jar, get_java_lib_folders, get_java_libraries, setup_java
 from commands.javadoc import javadoc
-from commands.python import get_python_libs, get_python_linker_args
+from commands.python import get_libpython, get_python_libs, get_python_linker_args
 from commands.scripts import build_scripts
 from commands.test import test
 from commands.util import is_windows
@@ -65,7 +65,13 @@ if __name__ == '__main__':
               ('JEP_NUMPY_ENABLED', numpy_found),
               ('VERSION', '"{0}"'.format(VERSION)),
           ]
-    ldlib = sysconfig.get_config_var('LDLIBRARY')
+    ldlib = get_libpython()
+    if ldlib:
+        # a libpython was found, so use the basename of the discovered path
+        ldlib = os.path.basename(ldlib)
+    else:
+        # no libpython was found, so use LDLIBRARY blindly
+        ldlib = sysconfig.get_config_var('LDLIBRARY')
     if ldlib:
         defines.append(('PYTHON_LDLIBRARY', '"' + ldlib + '"'))
     if is_windows():


### PR DESCRIPTION
As discussed in #392, conda environments on Linux using conda-forge Python have an unfortunate quirk where `LDLIBRARY` may point to a non-existent static `libpython3.x.a` library, rather than the actually present `libpython3.x.so` shared library. This patch improves the `get_libpython()` function of `commands.python` to handle this case, across both `MULTIARCH` and non-`MULTIARCH` locations.

```
$ python
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:04:18) 
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from distutils import sysconfig
>>> sysconfig.get_config_var('LDLIBRARY')
'libpython3.8.a'
>>> from commands.python import get_libpython
>>> get_libpython()
'/home/curtis/miniconda3/envs/jeptest/lib/libpython3.8.so'
```

It also updates `setup.py` to use the `get_libpython` function, rather than recapitulating similar logic.

Closes #392.

Two questions:

1.  I noticed that `setup.py` was using `import sysconfig` but `commands/python.py` uses `from distutils import sysconfig`. Looking at the respective docstrings, these two modules do seem distinct, and a quick web search did not help me understand how they differ, or which one is more recommended to use. So a consequence of this patch is that `setup.py` now transitively leans on `distutils.sysconfig` instead of `sysconfig`, although their behavior appears identical regarding the `get_config_var` function. Does this matter at all?

2.  ~~I could not figure out how to install jep from source to test this change. I tried `python setup.py build install` from a clean working copy, as indicated in the README, but it does not copy over the JAR file:~~ Edit: I figured out that `python setup.py install_lib` was also necessary. Should this be added to the README?

    <details><summary>What goes wrong with a developer install</summary>

    ```
    $ jep
    Error: Could not find or load main class jep.Run
    $ cat $(which jep) | grep jar
    cp="/home/curtis/miniconda3/envs/jeptest/lib/python3.8/site-packages/jep/jep-4.1.0.jar"
    $ ls /home/curtis/miniconda3/envs/jeptest/lib/python3.8/site-packages/jep/
    ls: cannot access '/home/curtis/miniconda3/envs/jeptest/lib/python3.8/site-packages/jep/': No such file or directory
    $ ls build/java/*.jar
    build/java/jep-4.1.0.jar          build/java/jep-4.1.0-test.jar
    build/java/jep-4.1.0-sources.jar  build/java/jep-4.1.0-test-sources.jar
    ```
    Although a subsequent `python setup.py test` does pass (230 tests, 26 skipped).
    </details>

    What am I doing wrong?