### PR TITLE
Switch build to setuptools.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Some benefits of embedding CPython in a JVM:
 
 Installation
 ------------
-Simply run ``pip install jep`` or download the source and run ``python setup.py build install``.
+Simply run ``pip install jep`` or download the source and run ``pip install .``.
 Building and installing require the JDK, Python, and optionally numpy to be installed beforehand.
 
 Dependencies

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,7 +1,6 @@
-from __future__ import print_function
+# https://github.com/pypa/setuptools/issues/2928
 from distutils.command.build import build
 from commands.java import build_java
-
 
 class jep_build(build):
     sub_commands = [

--- a/commands/build_ext.py
+++ b/commands/build_ext.py
@@ -1,10 +1,10 @@
 """
-Fork of distutils' build_ext command to handle using a
+Fork of setuptools' build_ext command to handle using a
 patched version of the msvc9compiler.
 """
 
 import os.path
-from distutils.command.build_ext import build_ext as old_build_ext
+from setuptools.command.build_ext import build_ext as old_build_ext
 
 
 class build_ext (old_build_ext):

--- a/commands/clean.py
+++ b/commands/clean.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from distutils.command.clean import clean
 import shutil
 

--- a/commands/dist.py
+++ b/commands/dist.py
@@ -1,4 +1,4 @@
-from distutils.dist import Distribution
+from setuptools.dist import Distribution
 
 
 class JepDistribution(Distribution):

--- a/commands/install_lib.py
+++ b/commands/install_lib.py
@@ -1,5 +1,5 @@
 """
-Fork of distutils' install_lib command that installs the native
+Fork of setuptools' install_lib command that installs the native
 jep library, the jar file, and the python files to the
 install_dir + 'jep', typically site-packages/jep.
 """
@@ -8,7 +8,7 @@ from commands.util import is_osx
 from commands.util import is_windows
 from commands.link_util import link_native_lib
 from commands.python import get_python_lib_dir
-from distutils.command.install_lib import install_lib
+from setuptools.command.install_lib import install_lib
 import os
 
 

--- a/commands/java.py
+++ b/commands/java.py
@@ -5,7 +5,6 @@ import shutil
 import os
 import fnmatch
 import traceback
-import subprocess
 import sys
 import logging
 
@@ -218,8 +217,8 @@ class build_java(Command):
     def build(self, *jclasses):
         jep = [x for x in list(*jclasses) if not x.startswith('src{0}test{0}java{0}'.format(os.sep))]
         tests = [x for x in list(*jclasses) if x.startswith('src{0}test{0}java{0}'.format(os.sep))]
-        subprocess.run([self.javac, '-deprecation', '-d', build_java.outdir, '-h', build_java.headeroutdir, '-classpath', 'src'] + jep)
-        subprocess.run([self.javac, '-deprecation', '-d', build_java.testoutdir, '-classpath', '{0}{1}src'.format(build_java.outdir, os.pathsep)] + tests)
+        self.spawn([self.javac, '-deprecation', '-d', build_java.outdir, '-h', build_java.headeroutdir, '-classpath', 'src'] + jep)
+        self.spawn([self.javac, '-deprecation', '-d', build_java.testoutdir, '-classpath', '{0}{1}src'.format(build_java.outdir, os.pathsep)] + tests)
         # Copy the source files over to the build directory to make src.jar's.
         self.copySrc('jep', jep)
         self.copySrc('jep.test', tests)
@@ -270,10 +269,10 @@ class build_jar(Command):
                 os.makedirs(dest_dir)
             shutil.copy(src, dest)
 
-        subprocess.run([self.jar, '-cf', 'build/java/jep-{0}-sources.jar'.format(self.version), '-C', 'build/java/jep.src/main/java', 'jep'])
-        subprocess.run([self.jar, '-cfe', 'build/java/jep-{0}.jar'.format(self.version), 'jep.Run', '-C', 'build/java', 'jep'])
-        subprocess.run([self.jar, '-cf', 'build/java/jep-{0}-test-sources.jar'.format(self.version), '-C', 'build/java/jep.test.src/test/java', 'jep'])
-        subprocess.run([self.jar, '-cfe', 'build/java/jep-{0}-test.jar'.format(self.version), 'test.jep.Test', '-C', 'build/java/test', 'jep'])
+        self.spawn([self.jar, '-cf', 'build/java/jep-{0}-sources.jar'.format(self.version), '-C', 'build/java/jep.src/main/java', 'jep'])
+        self.spawn([self.jar, '-cfe', 'build/java/jep-{0}.jar'.format(self.version), 'jep.Run', '-C', 'build/java', 'jep'])
+        self.spawn([self.jar, '-cf', 'build/java/jep-{0}-test-sources.jar'.format(self.version), '-C', 'build/java/jep.test.src/test/java', 'jep'])
+        self.spawn([self.jar, '-cfe', 'build/java/jep-{0}-test.jar'.format(self.version), 'test.jep.Test', '-C', 'build/java/test', 'jep'])
 
     def run(self):
         if not skip_java_build(self):

--- a/commands/javadoc.py
+++ b/commands/javadoc.py
@@ -1,5 +1,5 @@
-from distutils.cmd import Command
-from distutils.spawn import spawn
+from setuptools import Command
+import subprocess
 
 import os.path
 
@@ -25,7 +25,7 @@ class javadoc(Command):
         self.java_files = self.distribution.java_files
 
     def run(self):
-        spawn([self.javadoc, '-public', '-notimestamp',
+        subprocess.run([self.javadoc, '-public', '-notimestamp',
                              '-d', os.path.join(javadoc.outdir, self.version), 
                              '-sourcepath', 'src/main/java',
                              '-subpackages', 'jep' ])

--- a/commands/javadoc.py
+++ b/commands/javadoc.py
@@ -1,5 +1,4 @@
 from setuptools import Command
-import subprocess
 
 import os.path
 
@@ -25,7 +24,7 @@ class javadoc(Command):
         self.java_files = self.distribution.java_files
 
     def run(self):
-        subprocess.run([self.javadoc, '-public', '-notimestamp',
+        self.spawn([self.javadoc, '-public', '-notimestamp',
                              '-d', os.path.join(javadoc.outdir, self.version), 
                              '-sourcepath', 'src/main/java',
                              '-subpackages', 'jep' ])

--- a/commands/link_util.py
+++ b/commands/link_util.py
@@ -4,12 +4,11 @@ Helper functions for linking and finding libraries.
 
 from commands.util import is_osx
 from commands.util import is_windows
-from distutils import sysconfig
-from distutils.spawn import spawn
+
 import os
 import os.path
 import shutil
-
+import subprocess
 
 def link_native_lib(output_dir, jep_lib_path):
     """
@@ -36,15 +35,15 @@ def link_native_lib(output_dir, jep_lib_path):
         # Apple says to put the file at /Library/Java/Extensions/libjep.jnilib,
         # which is good for a permanent install but not so good when using
         # virtualenv or testing.
-        spawn(['ln',
+        subprocess.run(['ln',
                '-sf',
                '{0}'.format(jep_lib),
                '{0}'.format(os.path.join(output_dir, 'libjep.jnilib')), ])
 
     else:
-        # Otherwise, distutils outputs 'jep.so' which needs to be linked
+        # Otherwise, setuptools outputs 'jep.so' which needs to be linked
         # to 'libjep.so'. Otherwise the JVM will not find the library.
-        spawn(['ln',
+        subprocess.run(['ln',
                '-sf',
                '{0}'.format(jep_lib),
                '{0}'.format(os.path.join(output_dir, 'libjep.so')),

--- a/commands/link_util.py
+++ b/commands/link_util.py
@@ -35,7 +35,7 @@ def link_native_lib(output_dir, jep_lib_path):
         # Apple says to put the file at /Library/Java/Extensions/libjep.jnilib,
         # which is good for a permanent install but not so good when using
         # virtualenv or testing.
-        subprocess.run(['ln',
+        subprocess.check_call(['ln',
                '-sf',
                '{0}'.format(jep_lib),
                '{0}'.format(os.path.join(output_dir, 'libjep.jnilib')), ])
@@ -43,7 +43,7 @@ def link_native_lib(output_dir, jep_lib_path):
     else:
         # Otherwise, setuptools outputs 'jep.so' which needs to be linked
         # to 'libjep.so'. Otherwise the JVM will not find the library.
-        subprocess.run(['ln',
+        subprocess.check_call(['ln',
                '-sf',
                '{0}'.format(jep_lib),
                '{0}'.format(os.path.join(output_dir, 'libjep.so')),

--- a/commands/test.py
+++ b/commands/test.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
-from distutils.cmd import Command
-from distutils import sysconfig
+from setuptools import Command
+# https://github.com/pypa/setuptools/issues/2698
 from distutils.errors import DistutilsExecError
 from commands.util import configure_error
 from commands.util import is_osx
@@ -11,6 +10,7 @@ from commands.java import get_java_home
 import os
 import os.path
 import sys
+import sysconfig
 
 
 class test(Command):

--- a/commands/util.py
+++ b/commands/util.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
 from collections import namedtuple
-from distutils.util import get_platform
+from sysconfig import get_platform
 import subprocess
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
 import codecs
 
 import os
 
 import sysconfig
 
-from distutils.core import setup, Extension
-# if you want to build wheels, use setuptools instead of distutils
-# otherwise stick with distutils to avoid extra dependencies
-#from setuptools import setup, Extension
+from setuptools import setup, Extension
 
 from commands import jep_build
 from commands.clean import really_clean
@@ -143,5 +138,6 @@ if __name__ == '__main__':
               'clean': really_clean,
               'test': test,
           },
+          zip_safe=False
     )
 

--- a/src/main/scripts/jep
+++ b/src/main/scripts/jep
@@ -6,16 +6,23 @@
 {ld_library_path}
 {ld_preload}
 
-cp="{install_lib}jep/jep-{version}.jar"
+jep_dir={install_lib}jep
+
+if [ ! -d "$jep_dir" ]
+then
+    jep_dir={install_lib}{egg_dir}/jep
+fi
+
+cp="$jep_dir/jep-{version}.jar"
 if test "x$CLASSPATH" != "x"; then
     cp="$cp":"$CLASSPATH"
 fi
 
-jni_path="{install_lib}jep"
+jni_path=$jep_dir
 
 args=$*
 if test "x$args" = "x"; then
-  args="{install_lib}jep/console.py"
+  args="$jep_dir/console.py"
 fi
 
 exec java -classpath "$cp" -Djava.library.path="$jni_path" jep.Run $args


### PR DESCRIPTION
See #354. This change eliminates the DeprecationWarning during the build.

This does not remove every reference to distutils but I believe that any remaining references to distutils will continue to work after distutils is removed in Python 3.12 because of the distutils_hack in setuptools.

Many of the distutils references are related to choosing the c compiler in windows, since I do not have a local windows machine for testing I did not put any effort into windows. I did verify this change builds on windows on AppVeyor. I also have not tested on mac.

A few of the distutils references have open issues or fixes in newer versions of setuptools. I added comments to the setuptools issues and left the distutils code in for now so we are compatible with older versions of setuptools.