### PR TITLE
Implement custom MRO for PyJType.

### DIFF
--- a/src/test/java/jep/test/TestPyJType.java
+++ b/src/test/java/jep/test/TestPyJType.java
@@ -1,0 +1,27 @@
+package jep.test;
+
+public class TestPyJType {
+
+    public static interface Root {
+    }
+
+    public static interface Child extends Root{
+    }
+
+    /**
+     * The default Python mro cannot create a consistent method resolution
+     * order (MRO) for this interface.
+     */
+    public static interface ProblemInterface extends Root, Child {
+    }
+
+    /**
+     * The default Python mro cannot create a consistent method resolution
+     * order (MRO) for this class
+     */
+    public static class ProblemClass implements Root, Child {
+    }
+
+    public static class InheritedProblemClass implements ProblemInterface {
+    }
+}

--- a/src/test/python/test_regressions.py
+++ b/src/test/python/test_regressions.py
@@ -27,3 +27,7 @@ class TestRegressions(unittest.TestCase):
     def test_close_with_threads(self):
         jep_pipe(build_java_process_cmd('jep.test.TestCloseWithThreads'))
 
+    def test_pyjtype_mro(self):
+        # Both these throw errors with the default MRO
+        jep.findClass('jep.test.TestPyJType$ProblemClass')
+        jep.findClass('jep.test.TestPyJType$ProblemInterface')


### PR DESCRIPTION
Some Java classes have a type hierarchy that cannot be used with the Python C3 Method Resolution Order(MRO). This implements a custom MRO for PyJType so that it is possible to mirror the Java Class hierarchy in Python.