### PR TITLE
SharedInterpreters now share MemoryManager and java PyObjects.

### DIFF
--- a/release_notes/4.1-notes.rst
+++ b/release_notes/4.1-notes.rst
@@ -13,6 +13,14 @@ to use setuptools instead of distutils. This should not require changes for
 most users. The prefered command to install jep from a source directory is now 
 `pip install .`.
 
+PyObject can be shared between SharedInterpreters
+*************************************************
+In Java an instance of jep.python.PyObject(or any subclass) that is from a 
+SharedInterpreter can now be used on other Threads where a SharedInterpreter
+is currently active. At least one SharedInterpreter must remain open for this
+sharing because when the last SharedInterpreter is closed the PyObject becomes
+invalid to avoid memory leaks.
+
 Improvements to finding libraries
 *********************************
 * Additional logic was added to help the jep script find libpython in conda

--- a/src/main/c/Jep/convert_j2p.c
+++ b/src/main/c/Jep/convert_j2p.c
@@ -46,6 +46,9 @@ PyObject* JPyObject_As_PyObject(JNIEnv *env, jobject jobj)
 {
     PyObject *ret;
     jlong l = jep_python_PyObject_getPyObject(env, jobj);
+    if (process_java_exception(env)) {
+        return NULL;
+    }
     ret = (PyObject*) l;
     Py_INCREF(ret);
     return ret;

--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -73,7 +73,7 @@ public abstract class Jep implements Interpreter {
 
     private boolean interactive = false;
 
-    private final MemoryManager memoryManager = new MemoryManager();
+    private final MemoryManager memoryManager;
 
     private final boolean isSubInterpreter;
 
@@ -125,10 +125,10 @@ public abstract class Jep implements Interpreter {
      */
     @Deprecated
     public Jep(JepConfig config) throws JepException {
-        this(config, true);
+        this(config, true, new MemoryManager());
     }
 
-    protected Jep(JepConfig config, boolean useSubInterpreter)
+    protected Jep(JepConfig config, boolean useSubInterpreter, MemoryManager memoryManager)
             throws JepException {
         MainInterpreter mainInterpreter = MainInterpreter.getMainInterpreter();
         if (threadUsed.get()) {
@@ -141,6 +141,7 @@ public abstract class Jep implements Interpreter {
         }
 
         this.isSubInterpreter = useSubInterpreter;
+        this.memoryManager = memoryManager;
 
         if (config.classLoader == null) {
             this.classLoader = this.getClass().getClassLoader();
@@ -157,6 +158,7 @@ public abstract class Jep implements Interpreter {
         threadUsed.set(true);
         this.thread = Thread.currentThread();
         configureInterpreter(config);
+        this.memoryManager.openInterpreter(this);
     }
 
     protected void configureInterpreter(JepConfig config) throws JepException {
@@ -438,7 +440,7 @@ public abstract class Jep implements Interpreter {
             }
         }
 
-        getMemoryManager().cleanupReferences();
+        getMemoryManager().closeInterpreter(this);
 
         // don't attempt close twice if something goes wrong
         this.closed = true;

--- a/src/main/java/jep/JepAccess.java
+++ b/src/main/java/jep/JepAccess.java
@@ -38,21 +38,18 @@ import jep.python.MemoryManager;
  */
 public abstract class JepAccess {
 
-    protected final Jep jep;
-
-    protected JepAccess(Jep jep) {
-        this.jep = jep;
+    protected JepAccess() {
     }
 
-    protected long getThreadState() {
+    protected long getThreadState(Jep jep) {
         return jep.getThreadState();
     }
 
-    protected ClassLoader getClassLoader() {
+    protected ClassLoader getClassLoader(Jep jep) {
         return jep.getClassLoader();
     }
 
-    protected MemoryManager getMemoryManager() {
+    protected MemoryManager getMemoryManager(Jep jep) {
         return jep.getMemoryManager();
     }
 }

--- a/src/main/java/jep/SharedInterpreter.java
+++ b/src/main/java/jep/SharedInterpreter.java
@@ -24,6 +24,8 @@
  */
 package jep;
 
+import jep.python.MemoryManager;
+
 /**
  * Class for creating instances of Interpreters which share all imported
  * modules. In this case each SharedInterpreter still maintains distinct global
@@ -50,10 +52,12 @@ public class SharedInterpreter extends Jep {
 
     private static JepConfig config = new JepConfig();
 
+    private static final MemoryManager memoryManager = new MemoryManager();
+
     private static boolean initialized = false;
 
     public SharedInterpreter() throws JepException {
-        super(config, false);
+        super(config, false, memoryManager);
         exec("__name__ = '__main__'");
     }
 

--- a/src/main/java/jep/python/InvocationHandler.java
+++ b/src/main/java/jep/python/InvocationHandler.java
@@ -120,9 +120,7 @@ public class InvocationHandler implements java.lang.reflect.InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args)
             throws Throwable {
-        pyObject.checkValid();
-
-        return invoke(proxy, pyObject.pointer.tstate, pyObject.pointer.pyObject,
+        return invoke(proxy, pyObject.tstate(), pyObject.pointer.pyObject,
                 method, args, this.functionalInterface);
     }
 

--- a/src/main/java/jep/python/PyCallable.java
+++ b/src/main/java/jep/python/PyCallable.java
@@ -103,9 +103,8 @@ public class PyCallable extends PyObject {
      */
     public <T> T callAs(Class<T> expectedType, Object... args)
             throws JepException {
-        checkValid();
-        return expectedType.cast(call(pointer.tstate, pointer.pyObject, args,
-                null, expectedType));
+        return expectedType.cast(call(tstate(), pointer.pyObject, args, null,
+                expectedType));
     }
 
     /**
@@ -137,9 +136,8 @@ public class PyCallable extends PyObject {
      */
     public <T> T callAs(Class<T> expectedType, Map<String, Object> kwargs)
             throws JepException {
-        checkValid();
-        return expectedType.cast(call(pointer.tstate, pointer.pyObject, null,
-                kwargs, expectedType));
+        return expectedType.cast(call(tstate(), pointer.pyObject, null, kwargs,
+                expectedType));
     }
 
     /**
@@ -176,9 +174,8 @@ public class PyCallable extends PyObject {
      */
     public <T> T callAs(Class<T> expectedType, Object[] args,
             Map<String, Object> kwargs) throws JepException {
-        checkValid();
-        return expectedType.cast(call(pointer.tstate, pointer.pyObject, args,
-                kwargs, expectedType));
+        return expectedType.cast(call(tstate(), pointer.pyObject, args, kwargs,
+                expectedType));
     }
 
     private native Object call(long tstate, long pyObject, Object[] args,

--- a/src/main/java/jep/python/PyPointer.java
+++ b/src/main/java/jep/python/PyPointer.java
@@ -75,8 +75,8 @@ public class PyPointer extends WeakReference<PyObject> {
      */
     protected synchronized void dispose() throws JepException {
         if (!disposed) {
-            decref(memoryManager.getThreadState(), pyObject);
             disposed = true;
+            decref(memoryManager.getThreadState(), pyObject);
             memoryManager.removeReference(this);
         }
     }

--- a/src/main/java/jep/python/PyPointer.java
+++ b/src/main/java/jep/python/PyPointer.java
@@ -38,8 +38,6 @@ import jep.JepException;
  */
 public class PyPointer extends WeakReference<PyObject> {
 
-    protected final long tstate;
-
     protected final long pyObject;
 
     protected final MemoryManager memoryManager;
@@ -53,17 +51,14 @@ public class PyPointer extends WeakReference<PyObject> {
      *            the PyObject (or subclass) corresponding to this PyPointer
      * @param memoryManager
      *            the MemoryManager responsible for tracking this pointer
-     * @param tstate
-     *            the pointer to the JepThreadState
      * @param pyObject
      *            the pointer to the PyObject*
      * @throws JepException
      *             if an error occurs
      */
     protected PyPointer(PyObject referrent, MemoryManager memoryManager,
-            long tstate, long pyObject) throws JepException {
+            long pyObject) throws JepException {
         super(referrent, memoryManager.getReferenceQueue());
-        this.tstate = tstate;
         this.pyObject = pyObject;
         this.memoryManager = memoryManager;
         this.memoryManager.addReference(this);
@@ -80,9 +75,9 @@ public class PyPointer extends WeakReference<PyObject> {
      */
     protected synchronized void dispose() throws JepException {
         if (!disposed) {
+            decref(memoryManager.getThreadState(), pyObject);
             disposed = true;
             memoryManager.removeReference(this);
-            decref(tstate, pyObject);
         }
     }
 

--- a/src/test/java/jep/test/TestSharedInterpreter.java
+++ b/src/test/java/jep/test/TestSharedInterpreter.java
@@ -106,10 +106,10 @@ public class TestSharedInterpreter extends Thread {
             t.join();
             String test2 = list.getAttr("pop", PyCallable.class).callAs(String.class);
             String test = list.getAttr("pop", PyCallable.class).callAs(String.class);
-            if (!test.equals("test")) {
+            if (!"test".equals(test)) {
                 throw new IllegalStateException("Expecting 'test', not " + test); 
             }
-            if (!test2.equals("test2")) {
+            if (!"test2".equals(test2)) {
                 throw new IllegalStateException("Expecting 'test2', not " + test2); 
             }
             /* Make sure it doesn't work on threads without interpreters or in SubInterpreters. */

--- a/src/test/java/jep/test/TestSharedInterpreter.java
+++ b/src/test/java/jep/test/TestSharedInterpreter.java
@@ -2,6 +2,11 @@ package jep.test;
 
 import jep.Interpreter;
 import jep.SharedInterpreter;
+import jep.SubInterpreter;
+import jep.JepException;
+
+import jep.python.PyObject;
+import jep.python.PyCallable;
 
 /**
  * Tests that jep works without using sub-interpreters and verified that all
@@ -17,6 +22,7 @@ public class TestSharedInterpreter extends Thread {
         testSharedModule();
         testSharedJep();
         testSharedTypes();
+        testSharedJPyObject();
     }
 
     public static void testSharedModule() throws Throwable{
@@ -82,6 +88,53 @@ public class TestSharedInterpreter extends Thread {
             boolean pass = interp.getValue("id(type(sampleArrayList)) == id(type(sys.sampleArrayList))", Boolean.class);
             if (!pass) {
                 throw new IllegalStateException("types are different");
+            }
+        }
+    }
+
+    public static void testSharedJPyObject() throws Throwable {
+        try (Interpreter interp = new SharedInterpreter()) {
+            PyObject list = interp.getValue("[]", PyObject.class);
+            Thread t = new Thread(() -> {
+                try (Interpreter interp2 = new SharedInterpreter()) {
+                    list.getAttr("append", PyCallable.class).call("test");
+                    interp2.set("l", list);
+                    interp2.exec("l.append('test2')");
+                }
+            });
+            t.start();
+            t.join();
+            String test2 = list.getAttr("pop", PyCallable.class).callAs(String.class);
+            String test = list.getAttr("pop", PyCallable.class).callAs(String.class);
+            if (!test.equals("test")) {
+                throw new IllegalStateException("Expecting 'test', not " + test); 
+            }
+            if (!test2.equals("test2")) {
+                throw new IllegalStateException("Expecting 'test2', not " + test2); 
+            }
+            /* Make sure it doesn't work on threads without interpreters or in SubInterpreters. */
+            boolean[] pass = { true };
+            t = new Thread(() -> {
+                try {
+                    list.getAttr("append", PyCallable.class).call("test");
+                    pass[0] = false;
+                } catch (JepException e) {
+                }
+                try (Interpreter interp2 = new SubInterpreter()) {
+                    list.getAttr("append", PyCallable.class).call("test");
+                    pass[0] = false;
+                } catch (JepException e) {
+                }
+                try (Interpreter interp2 = new SubInterpreter()) {
+                    interp2.set("l", list);
+                    pass[0] = false;
+                } catch (JepException e) {
+                }
+            });
+            t.start();
+            t.join();
+            if (!pass[0]) {
+                throw new IllegalStateException("Invalid thread access should throw JepException");
             }
         }
     }


### PR DESCRIPTION
This enables all SharedInterpreters to use the same MemoryManager so that a PyPointer from any SharedInterpreter can be used on threads from any other SharedInterpreters. This requires internal changes to MemoryManager and the way it interacts with PyPointer because there is no longer a one-to-one relationship between a tstate and a MemoryManager, instead the same MemoryManager is valid for multiple tstates.

This should introduce more flexibility for developers. For ThreadPools performing the same task in different interpreters being able to reuse PyObjects should make them a more appealing feature.

I am hoping to expand this feature in a future release so that the MainInterpreter can clean up references from the shared MemoryManager, which would remove the requirement to keep an interpreter open by allowing cleanup without another Interpreter.
