### PR TITLE
Enable isinstance to work with PyJClass.

### DIFF
--- a/src/test/python/test_import.py
+++ b/src/test/python/test_import.py
@@ -57,4 +57,10 @@ class TestImport(unittest.TestCase):
         from java.util import Date
         self.assertTrue(isinstance(Date(), Object.__pytype__))
         self.assertTrue(isinstance(Date(), Serializable.__pytype__))
+        self.assertTrue(issubclass(Date.__pytype__, Object.__pytype__))
+        self.assertTrue(issubclass(Date.__pytype__, Serializable.__pytype__))
+        self.assertTrue(isinstance(Date(), Object))
+        self.assertTrue(isinstance(Date(), Serializable))
+        self.assertTrue(issubclass(Date, Object))
+        self.assertTrue(issubclass(Date, Serializable))
 


### PR DESCRIPTION
This fixes #438

I'm not sure if this will go in 4.1.1 or 4.2, since we haven't created a dev_4.2 branch yet I am currently targeting dev_4.1 but I may wait to merge this until we decide on a release plan.