### PR TITLE
Initial Implementation of PyBuiltins

### DIFF
--- a/src/main/java/jep/python/PyBuiltins.java
+++ b/src/main/java/jep/python/PyBuiltins.java
@@ -24,6 +24,8 @@
  */
 package jep.python;
 
+import java.util.Map;
+
 import jep.Interpreter;
 
 /**

--- a/src/main/java/jep/python/PyBuiltins.java
+++ b/src/main/java/jep/python/PyBuiltins.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2023 JEP AUTHORS.
+ *
+ * This file is licensed under the the zlib/libpng License.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any
+ * damages arising from the use of this software.
+ * 
+ * Permission is granted to anyone to use this software for any
+ * purpose, including commercial applications, and to alter it and
+ * redistribute it freely, subject to the following restrictions:
+ * 
+ *     1. The origin of this software must not be misrepresented; you
+ *     must not claim that you wrote the original software. If you use
+ *     this software in a product, an acknowledgment in the product
+ *     documentation would be appreciated but is not required.
+ * 
+ *     2. Altered source versions must be plainly marked as such, and
+ *     must not be misrepresented as being the original software.
+ * 
+ *     3. This notice may not be removed or altered from any source
+ *     distribution.
+ */
+package jep.python;
+
+import jep.Interpreter;
+
+/*
+ * Interface for accessing some of the functions of the Python builtins module from Java.
+ * More information on specific functions can be found at https://docs.python.org/3.5/library/functions.html
+ *
+ * To use this interface create an {@link Interpreter} and call {@link PyBuiltins#get(Interpreter)}.
+ *
+ * @since 4.2
+ */
+public interface PyBuiltins {
+
+    public boolean callable(Object object);
+
+    public PyObject compile(Object source, String filename, String mode);
+
+    public PyObject compile(Object source, String filename, String mode, int flags);
+
+    public PyObject compile(Object source, String filename, String mode, int flags, boolean dont_inherit);
+
+    public PyObject compile(Object source, String filename, String mode, int flags, boolean dont_inherit, int optimize);
+
+    public PyObject dict();
+
+    public void delattr(Object object, String name);
+
+    public String[] dir(Object object);
+
+    public Object eval(Object object, PyObject globals);
+
+    public Object eval(Object object, PyObject globals, PyObject locals);
+
+    public void exec(Object object, PyObject globals);
+
+    public void exec(Object object, PyObject globals, PyObject locals);
+
+    public PyObject frozenset();
+
+    public PyObject frozenset(Object iterable);
+
+    public Object getattr(Object object, String name);
+
+    public boolean hasattr(Object object, String name);
+
+    public long id(PyObject object);
+
+    public boolean isinstance(Object object, PyObject classinfo);
+
+    public boolean issubclass(PyObject cls, PyObject classinfo);
+
+    public PyObject list();
+
+    public PyObject list(Object iterable);
+
+    public PyObject object();
+
+    public PyObject set();
+
+    public PyObject set(Object iterable);
+
+    public void setattr(Object object, String name, Object value);
+
+    public PyObject tuple();
+
+    public PyObject tuple(Object iterable);
+
+    public PyCallable type(PyObject object);
+
+    public static PyBuiltins get(Interpreter interpreter) {
+        return interpreter.getValue("__import__('builtins')", PyObject.class).proxy(PyBuiltins.class);
+    }
+}

--- a/src/main/java/jep/python/PyBuiltins.java
+++ b/src/main/java/jep/python/PyBuiltins.java
@@ -40,57 +40,57 @@ public interface PyBuiltins {
 
     public boolean callable(Object object);
 
-    public PyObject compile(Object source, String filename, String mode);
-
-    public PyObject compile(Object source, String filename, String mode, int flags);
-
-    public PyObject compile(Object source, String filename, String mode, int flags, boolean dont_inherit);
-
-    public PyObject compile(Object source, String filename, String mode, int flags, boolean dont_inherit, int optimize);
-
-    public void delattr(Object object, String name);
+    public void delattr(PyObject object, String name);
 
     public PyObject dict();
 
-    public String[] dir(Object object);
+    public String[] dir(PyObject object);
 
-    public Object eval(Object object, PyObject globals);
+    public Object eval(String expression, PyObject globals);
 
-    public Object eval(Object object, PyObject globals, PyObject locals);
+    public Object eval(String expression, PyObject globals, PyObject locals);
 
-    public void exec(Object object, PyObject globals);
+    public void exec(String code, PyObject globals);
 
-    public void exec(Object object, PyObject globals, PyObject locals);
+    public void exec(String code, PyObject globals, PyObject locals);
 
     public PyObject frozenset();
 
-    public PyObject frozenset(Object iterable);
+    public PyObject frozenset(Iterable<?> iterable);
 
-    public Object getattr(Object object, String name);
+    public PyObject frozenset(Object[] array);
 
-    public boolean hasattr(Object object, String name);
+    public Object getattr(PyObject object, String name);
+
+    public boolean hasattr(PyObject object, String name);
 
     public long id(PyObject object);
 
-    public boolean isinstance(Object object, PyObject classinfo);
+    public boolean isinstance(PyObject object, PyObject classinfo);
 
     public boolean issubclass(PyObject cls, PyObject classinfo);
 
     public PyObject list();
 
-    public PyObject list(Object iterable);
+    public PyObject list(Iterable<?> iterable);
+
+    public PyObject list(Object[] array);
 
     public PyObject object();
 
     public PyObject set();
 
-    public PyObject set(Object iterable);
+    public PyObject set(Iterable<?> iterable);
 
-    public void setattr(Object object, String name, Object value);
+    public PyObject set(Object[] array);
+
+    public void setattr(PyObject object, String name, Object value);
 
     public PyObject tuple();
 
-    public PyObject tuple(Object iterable);
+    public PyObject tuple(Iterable<?> iterable);
+
+    public PyObject tuple(Object[] array);
 
     public PyCallable type(PyObject object);
 

--- a/src/main/java/jep/python/PyBuiltins.java
+++ b/src/main/java/jep/python/PyBuiltins.java
@@ -26,12 +26,14 @@ package jep.python;
 
 import jep.Interpreter;
 
-/*
+/**
  * Interface for accessing some of the functions of the Python builtins module from Java.
- * More information on specific functions can be found at https://docs.python.org/3.5/library/functions.html
- *
+ * More information on specific functions can be found in the
+ * <a href="https://docs.python.org/3/library/functions.html">Python Documentation</a>
+ * <p>
  * To use this interface create an {@link Interpreter} and call {@link PyBuiltins#get(Interpreter)}.
- *
+ * <p>
+ * PyBuiltins are not thread safe and have the same thread related restrictions as {@link PyObject}.
  * @since 4.2
  */
 public interface PyBuiltins {
@@ -46,9 +48,9 @@ public interface PyBuiltins {
 
     public PyObject compile(Object source, String filename, String mode, int flags, boolean dont_inherit, int optimize);
 
-    public PyObject dict();
-
     public void delattr(Object object, String name);
+
+    public PyObject dict();
 
     public String[] dir(Object object);
 

--- a/src/main/java/jep/python/PyBuiltins.java
+++ b/src/main/java/jep/python/PyBuiltins.java
@@ -44,6 +44,8 @@ public interface PyBuiltins {
 
     public PyObject dict();
 
+    public PyObject dict(Map<?,?> mapping);
+
     public String[] dir(PyObject object);
 
     public Object eval(String expression, PyObject globals);

--- a/src/test/java/jep/test/TestPyBuiltins.java
+++ b/src/test/java/jep/test/TestPyBuiltins.java
@@ -49,6 +49,10 @@ public class TestPyBuiltins {
             failure = "callable builtin returns an object is callable";
             return false;
         }
+        if (builtins.callable(7)){
+            failure = "callable builtin returns a number is callable";
+            return false;
+        }
         return true;
     }
 
@@ -58,6 +62,22 @@ public class TestPyBuiltins {
         if (result.intValue() != 2){
             failure = "compile builtin does not return 1 + 1 = 2";
             return false;
+        }
+        try {
+            code = builtins.compile("(:", "<string>", "eval");
+            failure = "Compile did not detect syntax error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("SyntaxError")) {
+                failure = "Not a SyntaxError: " + e.getMessage();
+            }
+        }
+        try {
+            code = builtins.compile(7, "<string>", "eval");
+            failure = "Compile did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -69,6 +89,14 @@ public class TestPyBuiltins {
         if (dir.contains("name")){
             failure = "delattr builtin does not delete value";
             return false;
+        }
+        try {
+            builtins.delattr(subobject, "fakeAttribute");
+            failure = "delattr did not detect attribute error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("AttributeError")) {
+                failure = "Not a AttributeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -107,6 +135,22 @@ public class TestPyBuiltins {
             failure = "eval builtin with locals does not return 1 + 1 = 2";
             return false;
         }
+        try {
+            result = (Number) builtins.eval("(:", globals, locals);
+            failure = "Eval did not detect syntax error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("SyntaxError")) {
+                failure = "Not a SyntaxError: " + e.getMessage();
+            }
+        }
+        try {
+            result = (Number) builtins.eval(7, globals, locals);
+            failure = "Eval did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
+        }
         return true;
     }
 
@@ -122,6 +166,22 @@ public class TestPyBuiltins {
         if (result.intValue() != 2){
             failure = "exec builtin with locals does not return 1 + 1 = 2";
             return false;
+        }
+        try {
+            builtins.exec("(:", globals);
+            failure = "Exec did not detect syntax error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("SyntaxError")) {
+                failure = "Not a SyntaxError: " + e.getMessage();
+            }
+        }
+        try {
+            builtins.exec(7, globals);
+            failure = "Exec did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -139,6 +199,14 @@ public class TestPyBuiltins {
             failure = "frozenset builtin does not return a full set";
             return false;
         }
+        try {
+            builtins.frozenset(7);
+            failure = "Frozen set did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
+        }
         return true;
     }
 
@@ -146,6 +214,14 @@ public class TestPyBuiltins {
         if (builtins.getattr(object, "__str__") == null){
             failure = "getattr builtin does not find __str__";
             return false;
+        }
+        try {
+            builtins.getattr(subobject, "fakeAttribute");
+            failure = "getattr did not detect attribute error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("AttributeError")) {
+                failure = "Not a AttributeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -183,6 +259,14 @@ public class TestPyBuiltins {
             failure = "isinstance builtin returns an object is a subtype";
             return false;
         }
+        try {
+            builtins.isinstance(object, object);
+            failure = "isinstance did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
+        }
         return true;
     }
 
@@ -191,9 +275,17 @@ public class TestPyBuiltins {
             failure = "issubclass builtin returns subtype is not a subclass of object";
             return false;
         }
-        if (builtins.isinstance(subtypeOne, subtypeTwo)){
+        if (builtins.issubclass(subtypeOne, subtypeTwo)){
             failure = "issubclass builtin returns unrelated subtype is a subclass";
             return false;
+        }
+        try {
+            builtins.issubclass(object, object);
+            failure = "issubclass did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -210,6 +302,14 @@ public class TestPyBuiltins {
         if (!listBuiltin.equals(listGetValue)){
             failure = "list builtin does not return a full list";
             return false;
+        }
+        try {
+            builtins.list(7);
+            failure = "List did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
         }
         return true;
     }
@@ -236,6 +336,14 @@ public class TestPyBuiltins {
             failure = "set builtin does not return a full set";
             return false;
         }
+        try {
+            builtins.set(7);
+            failure = "Set did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
+        }
         return true;
     }
 
@@ -260,6 +368,14 @@ public class TestPyBuiltins {
         if (!tupleBuiltin.equals(tupleGetValue)){
             failure = "tuple builtin does not return a full tuple";
             return false;
+        }
+        try {
+            builtins.tuple(7);
+            failure = "Tuple did not detect type error";
+        } catch (JepException e) {
+            if (!e.getMessage().contains("TypeError")) {
+                failure = "Not a TypeError: " + e.getMessage();
+            }
         }
         return true;
     }

--- a/src/test/java/jep/test/TestPyBuiltins.java
+++ b/src/test/java/jep/test/TestPyBuiltins.java
@@ -1,0 +1,336 @@
+package jep.test;
+
+import java.util.Set;
+
+import jep.Interpreter;
+import jep.SharedInterpreter;
+import jep.JepException;
+import jep.python.PyBuiltins;
+import jep.python.PyCallable;
+import jep.python.PyObject;
+
+public class TestPyBuiltins {
+
+    private Interpreter interp;
+
+    private PyBuiltins builtins;
+
+    /* An instance of the object type */
+    private PyObject object;
+    
+    /* The object type */
+    private PyCallable objectType;
+
+    /* A type that extends object */
+    private PyCallable subtypeOne;
+
+    /* Another type that extends object */
+    private PyCallable subtypeTwo;
+
+    /* An instance of one of the subtypes above*/
+    private PyObject subobject;
+
+    /* A dict for testing exec and eval */
+    private PyObject globals;
+
+    /* A dict for testing exec and eval */
+    private PyObject locals;
+
+    /* Set to a non-null value to fail the test */
+    private String failure;
+
+    private boolean testCallable() {
+        if (!builtins.callable(objectType)){
+            failure = "callable builtin returns object is not callable";
+            return false;
+        }
+        if (builtins.callable(object)){
+            failure = "callable builtin returns an object is callable";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testCompile() {
+        PyObject code = builtins.compile("1 + 1", "<string>", "eval");
+        Number result = (Number) builtins.eval(code, globals);
+        if (result.intValue() != 2){
+            failure = "compile builtin does not return 1 + 1 = 2";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testDelAttr() {
+        subobject.setAttr("name", "value");
+        builtins.delattr(subobject, "name");
+        Set<String> dir = Set.of(builtins.dir(subobject));
+        if (dir.contains("name")){
+            failure = "delattr builtin does not delete value";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testDict() {
+        PyObject dictBuiltin = builtins.dict();
+        PyObject dictGetValue = interp.getValue("{}", PyObject.class);
+        if (!dictBuiltin.equals(dictGetValue)){
+            failure = "dict builtin does not return an empty dict";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testDir() {
+        Set<String> dir = Set.of(builtins.dir(object));
+        if (!dir.contains("__str__")){
+            failure = "dir builtin does not report __str__";
+            return false;
+        }
+        if (dir.contains("fakeAttribute")){
+            failure = "dir builtin reports non-existent attribute";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testEval() {
+        Number result = (Number) builtins.eval("1+1", globals);
+        if (result.intValue() != 2){
+            failure = "eval builtin does not return 1 + 1 = 2";
+            return false;
+        }
+        result = (Number) builtins.eval("1+1", globals, locals);
+        if (result.intValue() != 2){
+            failure = "eval builtin with locals does not return 1 + 1 = 2";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testExec() {
+        builtins.exec("result = 1 + 1", globals);
+        Number result = (Number) builtins.eval("result", globals);
+        if (result.intValue() != 2){
+            failure = "exec builtin does not return 1 + 1 = 2";
+            return false;
+        }
+        builtins.exec("result = 1 + 1", globals);
+        result = (Number) builtins.eval("result", globals, locals);
+        if (result.intValue() != 2){
+            failure = "exec builtin with locals does not return 1 + 1 = 2";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testiFrozenSet() {
+        PyObject setBuiltin = builtins.frozenset();
+        PyObject setGetValue = interp.getValue("frozenset()", PyObject.class);
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "frozenset builtin does not return an empty set";
+            return false;
+        }
+        setBuiltin = builtins.frozenset(new String[] {"1", "2", "3"});
+        setGetValue = interp.getValue("{'1','2','3'}", PyObject.class);
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "frozenset builtin does not return a full set";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testGetAttr() {
+        if (builtins.getattr(object, "__str__") == null){
+            failure = "hasattr builtin does not find __str__";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testHasAttr() {
+        if (!builtins.hasattr(object, "__str__")){
+            failure = "hasattr builtin does not find __str__";
+            return false;
+        }
+        if (builtins.hasattr(object, "fakeAttribute")){
+            failure = "hasattr builtin found fakeAttribute";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testId() {
+        if (builtins.id(object) != builtins.id(object)){
+            failure = "id builtin returns inconsistent id";
+            return false;
+        }
+        if (builtins.id(object) == builtins.id(objectType)){
+            failure = "id builtin returns equal id for inequal objects";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testIsInstance() {
+        if (!builtins.isinstance(object, objectType)){
+            failure = "isinstance builtin returns an object is not an object type";
+            return false;
+        }
+        if (builtins.isinstance(object, subtypeOne)){
+            failure = "isinstance builtin returns an object is a subtype";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testIsSubClass() {
+        if (!builtins.issubclass(subtypeOne, objectType)){
+            failure = "issubclass builtin returns subtype is not a subclass of object";
+            return false;
+        }
+        if (builtins.isinstance(subtypeOne, subtypeTwo)){
+            failure = "issubclass builtin returns unrelated subtype is a subclass";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testList() {
+        PyObject listBuiltin = builtins.list();
+        PyObject listGetValue = interp.getValue("[]", PyObject.class);
+        if (!listBuiltin.equals(listGetValue)){
+            failure = "list builtin does not return an empty list";
+            return false;
+        }
+        listBuiltin = builtins.list(new String[] {"1", "2", "3"});
+        listGetValue = interp.getValue("['1','2','3']", PyObject.class);
+        if (!listBuiltin.equals(listGetValue)){
+            failure = "list builtin does not return a full list";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testObject() {
+        PyObject o = builtins.object();
+        if (!o.equals(object)){
+            failure = "object builtin does not return an empty object";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testSet() {
+        PyObject setBuiltin = builtins.set();
+        PyObject setGetValue = interp.getValue("set()", PyObject.class);
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "set builtin does not return an empty set";
+            return false;
+        }
+        setBuiltin = builtins.set(new String[] {"1", "2", "3"});
+        setGetValue = interp.getValue("{'1','2','3'}", PyObject.class);
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "set builtin does not return a full set";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testSetAttr() {
+        builtins.setattr(subobject, "name", "value");
+        if (!"value".equals(subobject.getAttr("name"))){
+            failure = "setattr builtin does not set value";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testTuple() {
+        PyObject tupleBuiltin = builtins.tuple();
+        PyObject tupleGetValue = interp.getValue("()", PyObject.class);
+        if (!tupleBuiltin.equals(tupleGetValue)){
+            failure = "tuple builtin does not return an empty tuple";
+            return false;
+        }
+        tupleBuiltin = builtins.tuple(new String[] {"1", "2", "3"});
+        tupleGetValue = interp.getValue("('1','2','3')", PyObject.class);
+        if (!tupleBuiltin.equals(tupleGetValue)){
+            failure = "tuple builtin does not return a full tuple";
+            return false;
+        }
+        return true;
+    }
+
+    private boolean testType() {
+        if (!objectType.equals(builtins.type(object))){
+            failure = "type builtin returns wrong type for an object";
+            return false;
+        }
+        return true;
+    }
+
+    public void runTest() {
+        try (Interpreter interp = new SharedInterpreter()) {
+            this.interp = interp;
+            builtins = PyBuiltins.get(interp);
+            objectType = interp.getValue("object", PyCallable.class);
+            object = interp.getValue("object()", PyObject.class);
+            subtypeOne = interp.getValue("type('subtypeone', (object,), {})", PyCallable.class);
+            subtypeTwo = interp.getValue("type('subtypetwo', (object,), {})", PyCallable.class);
+            subobject = ((PyCallable) subtypeOne).callAs(PyObject.class);
+            globals = interp.getValue("{}", PyObject.class);
+            locals = interp.getValue("{}", PyObject.class);
+            if (!testCallable()) {
+                return;
+            }
+            if (!testCompile()) {
+                return;
+            }
+            if (!testDelAttr()) {
+                return;
+            }
+            if (!testDir()) {
+                return;
+            }
+            if (!testEval()) {
+                return;
+            }
+            if (!testExec()) {
+                return;
+            }
+            if (!testGetAttr()) {
+                return;
+            }
+            if (!testHasAttr()) {
+                return;
+            }
+            if (!testId()) {
+                return;
+            }
+            if (!testIsInstance()) {
+                return;
+            }
+            if (!testIsSubClass()) {
+                return;
+            }
+            if (!testSetAttr()) {
+                return;
+            }
+            if (!testType()) {
+                return;
+            }
+        } catch (JepException e) {
+            failure = e.getMessage();
+        }
+    }
+
+    public static String test() throws InterruptedException{
+        TestPyBuiltins test = new TestPyBuiltins();
+        Thread t = new Thread(test::runTest);
+        t.start();
+        t.join();
+        return test.failure;
+    }
+}

--- a/src/test/java/jep/test/TestPyBuiltins.java
+++ b/src/test/java/jep/test/TestPyBuiltins.java
@@ -1,7 +1,9 @@
 package jep.test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import jep.Interpreter;
 import jep.SharedInterpreter;
@@ -80,6 +82,16 @@ public class TestPyBuiltins {
         PyObject dictGetValue = interp.getValue("{}", PyObject.class);
         if (!dictBuiltin.equals(dictGetValue)){
             failure = "dict builtin does not return an empty dict";
+            return false;
+        }
+        Map<String,Integer> map = new HashMap<>();
+        map.put("a", 1);
+        map.put("b", 2);
+        map.put("c", 3);
+        dictBuiltin = builtins.dict(map);
+        dictGetValue = interp.getValue("{'a':1, 'b':2, 'c':3}", PyObject.class);
+        if (!dictBuiltin.equals(dictGetValue)){
+            failure = "dict builtin does not return a dict from map";
             return false;
         }
         return true;

--- a/src/test/java/jep/test/TestPyBuiltins.java
+++ b/src/test/java/jep/test/TestPyBuiltins.java
@@ -56,32 +56,6 @@ public class TestPyBuiltins {
         return true;
     }
 
-    private boolean testCompile() {
-        PyObject code = builtins.compile("1 + 1", "<string>", "eval");
-        Number result = (Number) builtins.eval(code, globals);
-        if (result.intValue() != 2){
-            failure = "compile builtin does not return 1 + 1 = 2";
-            return false;
-        }
-        try {
-            code = builtins.compile("(:", "<string>", "eval");
-            failure = "Compile did not detect syntax error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("SyntaxError")) {
-                failure = "Not a SyntaxError: " + e.getMessage();
-            }
-        }
-        try {
-            code = builtins.compile(7, "<string>", "eval");
-            failure = "Compile did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
-        }
-        return true;
-    }
-
     private boolean testDelAttr() {
         subobject.setAttr("name", "value");
         builtins.delattr(subobject, "name");
@@ -143,14 +117,6 @@ public class TestPyBuiltins {
                 failure = "Not a SyntaxError: " + e.getMessage();
             }
         }
-        try {
-            result = (Number) builtins.eval(7, globals, locals);
-            failure = "Eval did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
-        }
         return true;
     }
 
@@ -175,14 +141,6 @@ public class TestPyBuiltins {
                 failure = "Not a SyntaxError: " + e.getMessage();
             }
         }
-        try {
-            builtins.exec(7, globals);
-            failure = "Exec did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
-        }
         return true;
     }
 
@@ -193,19 +151,17 @@ public class TestPyBuiltins {
             failure = "frozenset builtin does not return an empty set";
             return false;
         }
-        setBuiltin = builtins.frozenset(new String[] {"1", "2", "3"});
+        String[] array = new String[] {"1", "2", "3"};
         setGetValue = interp.getValue("{'1','2','3'}", PyObject.class);
+        setBuiltin = builtins.frozenset(array);
         if (!setBuiltin.equals(setGetValue)){
-            failure = "frozenset builtin does not return a full set";
+            failure = "frozenset builtin does not return a set from array";
             return false;
         }
-        try {
-            builtins.frozenset(7);
-            failure = "Frozen set did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
+        setBuiltin = builtins.frozenset(Arrays.asList(array));
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "frozenset builtin does not return a set from List";
+            return false;
         }
         return true;
     }
@@ -297,19 +253,17 @@ public class TestPyBuiltins {
             failure = "list builtin does not return an empty list";
             return false;
         }
-        listBuiltin = builtins.list(new String[] {"1", "2", "3"});
+        String[] array = new String[] {"1", "2", "3"};
         listGetValue = interp.getValue("['1','2','3']", PyObject.class);
+        listBuiltin = builtins.list(array);
         if (!listBuiltin.equals(listGetValue)){
-            failure = "list builtin does not return a full list";
+            failure = "list builtin does not return a list from array";
             return false;
         }
-        try {
-            builtins.list(7);
-            failure = "List did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
+        listBuiltin = builtins.list(Arrays.asList(array));
+        if (!listBuiltin.equals(listGetValue)){
+            failure = "list builtin does not return a list from List";
+            return false;
         }
         return true;
     }
@@ -330,19 +284,17 @@ public class TestPyBuiltins {
             failure = "set builtin does not return an empty set";
             return false;
         }
-        setBuiltin = builtins.set(new String[] {"1", "2", "3"});
+        String[] array = new String[] {"1", "2", "3"};
         setGetValue = interp.getValue("{'1','2','3'}", PyObject.class);
+        setBuiltin = builtins.set(array);
         if (!setBuiltin.equals(setGetValue)){
-            failure = "set builtin does not return a full set";
+            failure = "set builtin does not return a set from array";
             return false;
         }
-        try {
-            builtins.set(7);
-            failure = "Set did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
+        setBuiltin = builtins.set(Arrays.asList(array));
+        if (!setBuiltin.equals(setGetValue)){
+            failure = "set builtin does not return a set from List";
+            return false;
         }
         return true;
     }
@@ -363,19 +315,17 @@ public class TestPyBuiltins {
             failure = "tuple builtin does not return an empty tuple";
             return false;
         }
-        tupleBuiltin = builtins.tuple(new String[] {"1", "2", "3"});
+        String[] array = new String[] {"1", "2", "3"};
         tupleGetValue = interp.getValue("('1','2','3')", PyObject.class);
+        tupleBuiltin = builtins.tuple(array);
         if (!tupleBuiltin.equals(tupleGetValue)){
-            failure = "tuple builtin does not return a full tuple";
+            failure = "tuple builtin does not return a tuple from array";
             return false;
         }
-        try {
-            builtins.tuple(7);
-            failure = "Tuple did not detect type error";
-        } catch (JepException e) {
-            if (!e.getMessage().contains("TypeError")) {
-                failure = "Not a TypeError: " + e.getMessage();
-            }
+        tupleBuiltin = builtins.tuple(Arrays.asList(array));
+        if (!tupleBuiltin.equals(tupleGetValue)){
+            failure = "tuple builtin does not return a tuple from List";
+            return false;
         }
         return true;
     }
@@ -400,9 +350,6 @@ public class TestPyBuiltins {
             globals = interp.getValue("{}", PyObject.class);
             locals = interp.getValue("{}", PyObject.class);
             if (!testCallable()) {
-                return;
-            }
-            if (!testCompile()) {
                 return;
             }
             if (!testDelAttr()) {

--- a/src/test/java/jep/test/TestPyBuiltins.java
+++ b/src/test/java/jep/test/TestPyBuiltins.java
@@ -1,6 +1,7 @@
 package jep.test;
 
-import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 import jep.Interpreter;
 import jep.SharedInterpreter;
@@ -64,7 +65,7 @@ public class TestPyBuiltins {
     private boolean testDelAttr() {
         subobject.setAttr("name", "value");
         builtins.delattr(subobject, "name");
-        Set<String> dir = Set.of(builtins.dir(subobject));
+        List<String> dir = Arrays.asList(builtins.dir(subobject));
         if (dir.contains("name")){
             failure = "delattr builtin does not delete value";
             return false;
@@ -83,7 +84,7 @@ public class TestPyBuiltins {
     }
 
     private boolean testDir() {
-        Set<String> dir = Set.of(builtins.dir(object));
+        List<String> dir = Arrays.asList(builtins.dir(object));
         if (!dir.contains("__str__")){
             failure = "dir builtin does not report __str__";
             return false;
@@ -125,7 +126,7 @@ public class TestPyBuiltins {
         return true;
     }
 
-    private boolean testiFrozenSet() {
+    private boolean testFrozenSet() {
         PyObject setBuiltin = builtins.frozenset();
         PyObject setGetValue = interp.getValue("frozenset()", PyObject.class);
         if (!setBuiltin.equals(setGetValue)){
@@ -143,7 +144,7 @@ public class TestPyBuiltins {
 
     private boolean testGetAttr() {
         if (builtins.getattr(object, "__str__") == null){
-            failure = "hasattr builtin does not find __str__";
+            failure = "getattr builtin does not find __str__";
             return false;
         }
         return true;
@@ -215,7 +216,7 @@ public class TestPyBuiltins {
 
     private boolean testObject() {
         PyObject o = builtins.object();
-        if (!o.equals(object)){
+        if (!builtins.isinstance(object, objectType)){
             failure = "object builtin does not return an empty object";
             return false;
         }
@@ -291,6 +292,9 @@ public class TestPyBuiltins {
             if (!testDelAttr()) {
                 return;
             }
+            if (!testDict()) {
+                return;
+            }
             if (!testDir()) {
                 return;
             }
@@ -298,6 +302,9 @@ public class TestPyBuiltins {
                 return;
             }
             if (!testExec()) {
+                return;
+            }
+            if (!testFrozenSet()) {
                 return;
             }
             if (!testGetAttr()) {
@@ -315,7 +322,19 @@ public class TestPyBuiltins {
             if (!testIsSubClass()) {
                 return;
             }
+            if (!testList()) {
+                return;
+            }
+            if (!testObject()) {
+                return;
+            }
+            if (!testSet()) {
+                return;
+            }
             if (!testSetAttr()) {
+                return;
+            }
+            if (!testTuple()) {
                 return;
             }
             if (!testType()) {

--- a/src/test/python/test_pybuiltins.py
+++ b/src/test/python/test_pybuiltins.py
@@ -1,0 +1,9 @@
+import unittest
+import jep
+
+TestPyBuiltinsJava = jep.findClass('jep.test.TestPyBuiltins')
+
+class TestPyBuiltins(unittest.TestCase):
+
+    def test_pybuiltins(self):
+        self.assertEqual(None, TestPyBuiltinsJava.test())


### PR DESCRIPTION
This provides an interface to expose the functionality of the Python builtin module to Java using the Jep proxy functionality.

We have supported the proxy functionality for a long time but the only way for developers using Jep to use it is to write their own interface to use with the proxy. With this PR I am proposing that Jep can provide and maintain some interfaces for some standard Python objects to work with the Jep proxy functionality.

This PR exposes the builtin module because in some examples and tests I have written I have wanted a convenient way to access a few of these in Java and for others I can envision use cases where it might be helpful.

1. I think things like `type()` and `isinstance()` will be very helpful for type checking a `PyObject` in java.
2. `compile()`, `eval()` and `exec()` would be useful if anyone wants to build advanced interpreters beyond what Jep provides.
3. I included `dict()` because it would be a convenient way to get a globals /locals dict for exec().
4. I included the other collection types in case someone had a similar use cases where they needed to construct a Python collection directly.

I did not include functions that I didn't think would be particularly useful from Java, For example Java has it's own math library for doing `abs` and `pow`.

One of the important things to look at in the PR is the class of all the arguments and return types because often the proxy functionality would work equally well if we just used Object or PyObject everywhere. In places where certain types are required by the python functions I tried to be more specific and I tried to choose PyObject vs. Object based off what I thought made the most sense. The reason this is important is because if we need to change a return type or argument type in a future version of Jep then it could break backwards compatibility. Maintaining backwards compatibility is one of the major downsides to offering this type of support within Jep as opposed to requiring developers to create the interfaces themselves or offering them in a separate library.

It's also worth mentioning that everything PyBuiltins does could easily be done with `Interpreter.invoke()` or `Interpreter.getValue()` so this adds no new functionality to Jep, however I feel PyBuiltins provides a more object oriented way of accessing the functionality that will be more convenient for some Java developers using Jep.