### PR TITLE
Create conversion functions for Java to numpy conversions.

### DIFF
--- a/src/main/c/Include/jep_numpy.h
+++ b/src/main/c/Include/jep_numpy.h
@@ -43,17 +43,13 @@
 /* this whole file is a no-op if numpy support is disabled */
 #if JEP_NUMPY_ENABLED
 
-    /* methods to support numpy <-> java conversion */
+    /* methods to support numpy -> java conversion */
     int npy_scalar_check(PyObject*);
     jobject convert_npy_scalar_jobject(JNIEnv*, PyObject*, jclass);
     int npy_array_check(PyObject*);
-    int jndarray_check(JNIEnv*, jobject);
     jobject convert_pyndarray_jobject(JNIEnv*, PyObject*, jclass);
-    PyObject* convert_jndarray_pyndarray(JNIEnv*, jobject);
 
-    int jdndarray_check(JNIEnv*, jobject);
-    PyObject* convert_jdndarray_pyndarray(JNIEnv*, PyObject*);
-
+    int load_numpy_conversions(JNIEnv*);
 #endif // if numpy is enabled
 
 

--- a/src/main/c/Jep/convert_j2p.c
+++ b/src/main/c/Jep/convert_j2p.c
@@ -218,10 +218,6 @@ PyObject* jobject_As_PyObject(JNIEnv *env, jobject jobj)
         result = Character_As_PyObject(env, jobj);
     } else if ((*env)->IsAssignableFrom(env, class, JPYOBJECT_TYPE)) {
         result = JPyObject_As_PyObject(env, jobj);
-#if JEP_NUMPY_ENABLED
-    } else if (jndarray_check(env, jobj)) {
-        result = convert_jndarray_pyndarray(env, jobj);
-#endif
     } else {
         jboolean array = java_lang_Class_isArray(env, class);
         if ((*env)->ExceptionCheck(env)) {
@@ -245,22 +241,6 @@ PyObject* jobject_As_PyObject(JNIEnv *env, jobject jobj)
                 if (result) {
                     result = pyjobject_convert_pyobject(result);
                 }
-#if JEP_NUMPY_ENABLED
-                /*
-                 * check for jep/DirectNDArray and autoconvert to numpy.ndarray
-                 * pyjobject
-                 */
-                if (jdndarray_check(env, jobj)) {
-                    PyObject* ndarray = convert_jdndarray_pyndarray(env, result);
-                    if (ndarray) {
-                        result = ndarray;
-                    } else {
-                        Py_CLEAR(result);
-                    }
-                } else if (PyErr_Occurred()) {
-                    Py_CLEAR(result);
-                }
-#endif
             }
         }
     }

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -222,6 +222,11 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
         }
         /* still held by sys.modules. */
         Py_DECREF(modjep);
+#if JEP_NUMPY_ENABLED
+        if (load_numpy_conversions(env)) {
+            return -1;
+        }
+#endif
     }
     return 0;
 }


### PR DESCRIPTION
Long term I hope to move most or all of the numpy specific logic to jep_numpy so that it is easier to disable/enable at runtime rather than compile time. This is a small step in that direction by removing the numpy specific logic in convert_j2p.c.