### PR TITLE
Add optional to allow execution script in different thread

### DIFF
--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -79,6 +79,8 @@ public abstract class Jep implements Interpreter {
 
     // windows requires this as unix newline...
     private static final String LINE_SEP = "\n";
+    
+    private boolean useCurrentThread = false;
 
     /**
      * Tracks if this thread has been used for an interpreter before. Using
@@ -212,6 +214,10 @@ public abstract class Jep implements Interpreter {
 
     private native long init(ClassLoader classloader, boolean hasSharedModules,
             boolean useSubinterpreter) throws JepException;
+    
+    public void setUseCurrentThread(boolean flag) {
+	this.useCurrentThread = flag;
+    }
 
     /**
      * Checks if the current thread is valid for the method call. All calls must
@@ -226,7 +232,7 @@ public abstract class Jep implements Interpreter {
      */
     @Deprecated
     public void isValidThread() throws JepException {
-        if (this.thread != Thread.currentThread())
+        if (this.useCurrentThread && this.thread != Thread.currentThread())
             throw new JepException("Invalid thread access.");
         if (this.closed)
             throw new JepException("Jep instance has been closed.");

--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -80,7 +80,7 @@ public abstract class Jep implements Interpreter {
     // windows requires this as unix newline...
     private static final String LINE_SEP = "\n";
     
-    private boolean useCurrentThread = false;
+    private boolean useCurrentThread = true;
 
     /**
      * Tracks if this thread has been used for an interpreter before. Using

--- a/src/main/java/jep/SharedInterpreter.java
+++ b/src/main/java/jep/SharedInterpreter.java
@@ -60,6 +60,11 @@ public class SharedInterpreter extends Jep {
         super(config, false, memoryManager);
         exec("__name__ = '__main__'");
     }
+    
+    public SharedInterpreter(boolean useCurrentThread) throws JepException {
+	this();
+	setUseCurrentThread(useCurrentThread);
+    }
 
     @Override
     protected void configureInterpreter(JepConfig config) throws JepException {


### PR DESCRIPTION
Hi! I'm ran into a problem with situation, when I trying to call multiple short scripts in the created singleton `Interpreter`.
To resolve this issue, I added optional flag to disable checking of `currentThread` in the `isValidThread` method.