### PR TITLE
add shared memory between SubInterpreters

### DIFF
--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -130,8 +130,13 @@ public abstract class Jep implements Interpreter {
 
     protected Jep(JepConfig config, boolean useSubInterpreter, MemoryManager memoryManager)
             throws JepException {
+        this(config, useSubInterpreter, memoryManager, false);
+    }
+
+    protected Jep(JepConfig config, boolean useSubInterpreter, MemoryManager memoryManager, boolean useSharedMemory)
+            throws JepException {
         MainInterpreter mainInterpreter = MainInterpreter.getMainInterpreter();
-        if (threadUsed.get()) {
+        if (!useSharedMemory && threadUsed.get()) {
             Thread current = Thread.currentThread();
             StringBuilder warning = new StringBuilder(THREAD_WARN)
                     .append("Unsafe reuse of thread ").append(current.getName())

--- a/src/main/java/jep/JepConfig.java
+++ b/src/main/java/jep/JepConfig.java
@@ -24,6 +24,8 @@
  */
 package jep;
 
+import jep.python.MemoryManager;
+
 import java.io.File;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -57,6 +59,8 @@ public class JepConfig {
     protected OutputStream redirectStderr = null;
 
     protected Set<String> sharedModules = null;
+
+    protected MemoryManager sharedMemoryManager = null;
 
     /**
      * Sets a path of directories separated by File.pathSeparator that will be
@@ -199,6 +203,15 @@ public class JepConfig {
      */
     public SubInterpreter createSubInterpreter() throws JepException {
         return new SubInterpreter(this);
+    }
+
+    public SubInterpreter createSubInterpreterSharedMemory() {
+        if (sharedMemoryManager == null) {
+            SubInterpreter interpreter = new SubInterpreter(this);
+            sharedMemoryManager = interpreter.getMemoryManager();
+            return interpreter;
+        }
+        return new SubInterpreter(this, sharedMemoryManager, true);
     }
 
 }

--- a/src/main/java/jep/SubInterpreter.java
+++ b/src/main/java/jep/SubInterpreter.java
@@ -24,6 +24,8 @@
  */
 package jep;
 
+import jep.python.MemoryManager;
+
 /**
  * Class for creating instances of Interpreters which are sandboxed from other
  * Interpreters. Sub-interpreters isolate different SubInterpreter instances,
@@ -61,6 +63,10 @@ public class SubInterpreter extends Jep {
     @SuppressWarnings("deprecation")
     public SubInterpreter(JepConfig config) throws JepException {
         super(config);
+    }
+
+    public SubInterpreter(JepConfig config, MemoryManager memoryManager, boolean useSharedMemory) throws JepException {
+        super(config, true, memoryManager, useSharedMemory);
     }
 
 }

--- a/src/test/java/jep/test/TestSharedMemoryInSubInterpreter.java
+++ b/src/test/java/jep/test/TestSharedMemoryInSubInterpreter.java
@@ -1,0 +1,79 @@
+package jep.test;
+
+import jep.Interpreter;
+import jep.JepConfig;
+import jep.JepException;
+
+import java.util.Random;
+
+public class TestSharedMemoryInSubInterpreter {
+    private JepConfig config;
+    private Interpreter mainIterp;
+    private Object pythonObject;
+
+    public static void main(String[] args) {
+        TestSharedMemoryInSubInterpreter app = new TestSharedMemoryInSubInterpreter();
+        app.init();
+
+        // test in single thread
+        int v = app.callMethodAdd(100, 50);
+        System.out.println("Add (100, 50) = " + v);
+
+        v = app.callMethodAdd(10, 10);
+        System.out.println("Sub (10, 10) = " + v);
+
+        // test with separate threads
+        Random random = new Random();
+
+        for (int i = 0; i < 3; i++) {
+            Thread thread = new Thread(() -> {
+                System.out.println(Thread.currentThread().getName() + ": started");
+                int a = random.nextInt(100);
+                int b = random.nextInt(100);
+
+                int r = app.callMethodAdd(a, b);
+                String result = a + " + " + b + " = " + r;
+
+                try {
+                    Thread.sleep(1000L);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                System.out.println(Thread.currentThread().getName() + ": result(" + result + ")");
+                System.out.println(Thread.currentThread().getName() + ": finish");
+            });
+            thread.start();
+        }
+    }
+
+    private void init() throws JepException {
+        String initScript =
+                "class SimpleObject:\n" +
+                        "  def add(self, a, b):\n" +
+                        "    return a + b\n" +
+                        "  def sub(self, a, b):\n" +
+                        "    return a - b\n" +
+                        "myobj = SimpleObject()";
+
+        // config need for sharing memory
+        config = new JepConfig();
+
+        Interpreter interp = config.createSubInterpreterSharedMemory();
+        interp.exec(initScript);
+        pythonObject = interp.getValue("myobj", Object.class);
+        // store main interpreter with shared memory
+        mainIterp = interp;
+    }
+
+    private int callMethodAdd(int a, int b) throws JepException {
+        // this interpreter accesses the object created in the main interpreter
+        try (Interpreter interp = config.createSubInterpreterSharedMemory()) {
+            interp.set("obj", pythonObject);
+            interp.set("a", a);
+            interp.set("b", b);
+            interp.exec("result = obj.add(a, b)");
+            return interp.getValue("result", Integer.class);
+        }
+    }
+
+}


### PR DESCRIPTION
The pull request before, was not correct, so I try to fix...
This feature will give me what I need. You can check test file `TestSharedMemoryInSubInterpreter` for more detail.
It works in the default state as before, as it is only like additional parameter and may be optional (or experimental). Not all developers need to use it, but the main reason why it's needed in my case is that: I want to integrate java with python directly in the spring-cloud application. There are many ways to do such an integration, but I need use python as a micro-service in the spring-cloud ecosystem, and this feature will allow me not to worry about workarround in the load-balancing and use python facilities closer to java application.