### PR TITLE
implement keys() and items() on PyJMap

### DIFF
--- a/release_notes/4.2-notes.rst
+++ b/release_notes/4.2-notes.rst
@@ -21,6 +21,11 @@ from a Java object. For more details on how to register a custom converter see
 `the wiki <https://github.com/ninia/jep/wiki/Accessing-Java-Objects-in-Python#custom-conversion-functions>`_
 or exec ``help(jep.setJavaToPythonConverter)`` in a Jep interpreter.
 
+PyJType for java.util.Map now implements keys() and items()
+***********************************************************
+This allows Java Maps to be easily converted to Python dictionaries in
+situations where duck typing is not good enough and a dictionary is required.
+
 Additions of PyBuiltins
 ***********************
 The `PyBuiltins <http://ninia.github.io/jep/javadoc/4.2/jep/python/PyBuiltin.html>`_

--- a/src/main/c/Objects/pyjmap.c
+++ b/src/main/c/Objects/pyjmap.c
@@ -43,7 +43,6 @@ static Py_ssize_t pyjmap_len(PyObject *self)
     return len;
 }
 
-
 /*
  * Method for checking if a key is in the dictionary.  For example,
  * if key in o:
@@ -70,7 +69,6 @@ static int pyjmap_contains_key(PyObject *self, PyObject *key)
         goto FINALLY;
     }
 
-
     if (jresult) {
         result = 1;
     } else {
@@ -80,7 +78,6 @@ FINALLY:
     (*env)->PopLocalFrame(env, NULL);
     return result;
 }
-
 
 /*
  * Method for the getting items with the [key] operator on pyjmap.  For
@@ -189,7 +186,6 @@ FINALLY:
     return result;
 }
 
-
 /*
  * Method for iterating over the keys of the dictionary.  For example,
  * for key in o:
@@ -211,7 +207,6 @@ static PyObject* pyjmap_getiter(PyObject* obj)
         goto FINALLY;
     }
 
-
     iter = java_lang_Iterable_iterator(env, set);
     if (process_java_exception(env) || !iter) {
         goto FINALLY;
@@ -223,6 +218,153 @@ FINALLY:
     return result;
 }
 
+static PyObject* pyjmap_keys(PyObject* self, PyObject* args)
+{
+    jobject    keyset = NULL;
+    PyObject  *result = NULL;
+    PyJObject *pyjob  = (PyJObject*) self;
+    JNIEnv    *env    = pyembed_get_env();
+
+    if ((*env)->PushLocalFrame(env, JLOCAL_REFS) != 0) {
+        process_java_exception(env);
+        return NULL;
+    }
+
+    keyset = java_util_Map_keySet(env, pyjob->object);
+    if (process_java_exception(env) || !keyset) {
+        goto FINALLY;
+    }
+
+    result = jobject_As_PyObject(env, keyset);
+FINALLY:
+    (*env)->PopLocalFrame(env, NULL);
+    return result;
+}
+
+static PyObject* pyjmap_items(PyObject* self, PyObject* args)
+{
+    jobject    entrySet = NULL;
+    jobject    itr      = NULL;
+    PyObject  *pylist   = NULL;
+    PyObject  *result   = NULL;
+    int        size     = 0;
+    int        index    = 0;
+    PyJObject *pyjob    = (PyJObject*) self;
+    JNIEnv    *env      = pyembed_get_env();
+
+    if ((*env)->PushLocalFrame(env, JLOCAL_REFS) != 0) {
+        process_java_exception(env);
+    }
+
+    entrySet = java_util_Map_entrySet(env, pyjob->object);
+    if (process_java_exception(env) || !entrySet) {
+        goto FINALLY;
+    }
+
+    size = java_util_Map_size(env, pyjob->object);
+    if (process_java_exception(env)) {
+        goto FINALLY;
+    }
+
+    itr = java_lang_Iterable_iterator(env, entrySet);
+    if (process_java_exception(env) || !itr) {
+        goto FINALLY;
+    }
+
+    pylist = PyList_New(size);
+    while (java_util_Iterator_hasNext(env, itr)) {
+        jobject  next;
+        jobject  key;
+        jobject  value;
+        PyObject *pykey;
+        PyObject *pyval;
+        PyObject *pytuple;
+
+        next = java_util_Iterator_next(env, itr);
+        if (!next) {
+            if (!process_java_exception(env)) {
+                THROW_JEP(env, "Map.entrySet().iterator().next() returned null");
+            }
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+
+        // convert Map.Entry's key to a PyObject*
+        key = java_util_Map_Entry_getKey(env, next);
+        if (process_java_exception(env)) {
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+        pykey = jobject_As_PyObject(env, key);
+        if (!pykey) {
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+
+        // convert Map.Entry's value to a PyObject*
+        value = java_util_Map_Entry_getValue(env, next);
+        if (process_java_exception(env)) {
+            Py_DECREF(pykey);
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+        pyval = jobject_As_PyObject(env, value);
+        if (!pyval) {
+            Py_DECREF(pykey);
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+
+        pytuple = PyTuple_Pack(2, pykey, pyval);
+        if (!pytuple) {
+            Py_DECREF(pykey);
+            Py_DECREF(pyval);
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+        Py_DECREF(pykey);
+        Py_DECREF(pyval);
+
+        if (PyList_SetItem(pylist, index, pytuple) != 0) {
+            process_py_exception(env);
+            Py_DECREF(pytuple);
+            Py_DECREF(pylist);
+            goto FINALLY;
+        }
+
+        (*env)->DeleteLocalRef(env, next);
+        if (key) {
+            (*env)->DeleteLocalRef(env, key);
+        }
+        if (value) {
+            (*env)->DeleteLocalRef(env, value);
+        }
+
+        index += 1;
+    }  // end of while loop
+
+    result = pylist;
+FINALLY:
+    (*env)->PopLocalFrame(env, NULL);
+    return result;
+}
+
+static PyMethodDef pyjmap_methods[] = {
+    {
+        "keys",
+        pyjmap_keys,
+        METH_NOARGS,
+        "Returns a list of keys in the map"
+    },
+    {
+        "items",
+        pyjmap_items,
+        METH_NOARGS,
+        "Returns a list of the items in the map, where each item is a tuple containing a key-value pair"
+    },
+    { NULL, NULL }
+};
+
 static PyType_Slot slots[] = {
     {Py_tp_doc, "Jep java.util.Map"},
     {Py_tp_iter, (void*) pyjmap_getiter},
@@ -232,6 +374,8 @@ static PyType_Slot slots[] = {
     {Py_mp_length, (void*) pyjmap_len},
     {Py_mp_subscript, (void*) pyjmap_getitem},
     {Py_mp_ass_subscript, (void*) pyjmap_setitem},
+    // methods slot
+    {Py_tp_methods, (void*) pyjmap_methods},
     {0, NULL},
 };
 PyType_Spec PyJMap_Spec = {

--- a/src/main/c/Objects/pyjmap.c
+++ b/src/main/c/Objects/pyjmap.c
@@ -278,7 +278,7 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
     }
 
     pylist = PyList_New(size);
-    while (index < size) {
+    for (index = 0;  index < size; index++) {
         jobject  next;
         jobject  key;
         jobject  value;
@@ -346,8 +346,7 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
             (*env)->DeleteLocalRef(env, value);
         }
 
-        index += 1;
-    }  // end of while loop
+    }  // end of for loop
 
     result = pylist;
 FINALLY:

--- a/src/main/c/Objects/pyjmap.c
+++ b/src/main/c/Objects/pyjmap.c
@@ -231,7 +231,7 @@ static PyObject* pyjmap_keys(PyObject* self, PyObject* args)
     }
 
     keyset = java_util_Map_keySet(env, pyjob->object);
-    if (process_java_exception(env) || !keyset) {
+    if (process_java_exception(env)) {
         goto FINALLY;
     }
 
@@ -257,8 +257,10 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
     }
 
     entrySet = java_util_Map_entrySet(env, pyjob->object);
-    if (process_java_exception(env) || !entrySet) {
-        PyErr_SetString(PyExc_RuntimeError, "Map.entrySet() returned null");
+    if (!entrySet) {
+        if (!process_java_exception(env)) {
+            PyErr_SetString(PyExc_RuntimeError, "Map.entrySet() returned null");
+        }
         goto FINALLY;
     }
 
@@ -268,7 +270,10 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
     }
 
     itr = java_lang_Iterable_iterator(env, entrySet);
-    if (process_java_exception(env) || !itr) {
+    if (!itr) {
+        if (!process_java_exception(env)) {
+            PyErr_SetString(PyExc_RuntimeError, "Map.entrySet().iterator() returned null");
+        }
         goto FINALLY;
     }
 

--- a/src/main/c/Objects/pyjmap.c
+++ b/src/main/c/Objects/pyjmap.c
@@ -258,6 +258,7 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
 
     entrySet = java_util_Map_entrySet(env, pyjob->object);
     if (process_java_exception(env) || !entrySet) {
+        PyErr_SetString(PyExc_RuntimeError, "Map.entrySet() returned null");
         goto FINALLY;
     }
 
@@ -272,7 +273,7 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
     }
 
     pylist = PyList_New(size);
-    while (java_util_Iterator_hasNext(env, itr)) {
+    while (index < size) {
         jobject  next;
         jobject  key;
         jobject  value;
@@ -283,7 +284,8 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
         next = java_util_Iterator_next(env, itr);
         if (!next) {
             if (!process_java_exception(env)) {
-                THROW_JEP(env, "Map.entrySet().iterator().next() returned null");
+                PyErr_SetString(PyExc_RuntimeError,
+                                "Map.entrySet().iterator().next() returned null");
             }
             Py_DECREF(pylist);
             goto FINALLY;
@@ -326,7 +328,6 @@ static PyObject* pyjmap_items(PyObject* self, PyObject* args)
         Py_DECREF(pyval);
 
         if (PyList_SetItem(pylist, index, pytuple) != 0) {
-            process_py_exception(env);
             Py_DECREF(pytuple);
             Py_DECREF(pylist);
             goto FINALLY;

--- a/src/test/python/test_maps.py
+++ b/src/test/python/test_maps.py
@@ -1,7 +1,5 @@
 import unittest
 
-from collections.abc import Mapping
-
 from java.util import HashMap
 
 
@@ -58,3 +56,23 @@ class TestMaps(unittest.TestCase):
         for i in jmap:
             pydict[i] = jmap[i]
         self.assertEqual(pydict, pymap)
+
+    def test_keys(self):
+        jmap = makeJavaMap()
+        keylist = jmap.keys()
+        self.assertIn("a", keylist)
+        self.assertIn("b", keylist)
+        self.assertIn("c", keylist)
+        self.assertNotIn("d", keylist)
+        self.assertNotIn(2, keylist)
+
+    def test_items(self):
+        jmap = makeJavaMap()
+        itemlist = jmap.items()
+        self.assertIn(("a", -1), itemlist)
+        self.assertIn(("b", 2), itemlist)
+        self.assertIn(("c", "XYZ"), itemlist)
+        self.assertNotIn(("a", 1), itemlist)
+        self.assertNotIn(("a", 2), itemlist)
+        self.assertNotIn("a", itemlist)
+        self.assertNotIn(2, itemlist)

--- a/src/test/python/test_maps.py
+++ b/src/test/python/test_maps.py
@@ -76,3 +76,9 @@ class TestMaps(unittest.TestCase):
         self.assertNotIn(("a", 2), itemlist)
         self.assertNotIn("a", itemlist)
         self.assertNotIn(2, itemlist)
+
+    def test_map_to_dict(self):
+        jmap = makeJavaMap()
+        pydict = dict(jmap)
+        for k in pydict:
+            self.assertEqual(pydict[k], jmap[k])


### PR DESCRIPTION
Implementing keys() on PyJMap enables you to seamlessly convert a java.util.Map into a Python dictionary.  In general this is unnecessary since PyJMap already supports common syntax used for dictionaries, but in case someone really needed a dictionary instance now it is easy to convert.  For example, in the following code the line `d = dict(x)` would fail before this change:
```python
from java.util import HashMap
x = HashMap()
x['abc'] = 'def'
x[35] = 'ghi'
d = dict(x)
```
I also implemented items() for completeness.