### PR TITLE
Java FunctionalInterfaces are automatically callable in Python

### DIFF
--- a/release_notes/4.2-notes.rst
+++ b/release_notes/4.2-notes.rst
@@ -31,3 +31,18 @@ Additions of PyBuiltins
 The `PyBuiltins <http://ninia.github.io/jep/javadoc/4.2/jep/python/PyBuiltin.html>`_
 class provides makes it easier to call some of the builtin Python functions
 from Java.
+
+Java FunctionalInterfaces are automatically callable in Python 
+**************************************************************
+When a Java object implementing a
+`FunctionalInterface <https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/FunctionalInterface.html>`_
+is used in Python it is automatically 
+`callable <https://docs.python.org/3/glossary.html#term-callable>`_
+and the `__call__` method will be set to the abstract method of the interface.
+Similar to the Java compiler, the type is not required to have the
+FunctionalInterface annotation to be treated as a functional interface.
+For example a Kava Function can be called directly without using the accept method:
+::
+    from java.util.function import Function
+    identity = Function.identity()
+    result = identity("abc") # Same behavior as identity.accept("abc")

--- a/release_notes/4.2-notes.rst
+++ b/release_notes/4.2-notes.rst
@@ -41,7 +41,7 @@ is used in Python it is automatically
 and the `__call__` method will be set to the abstract method of the interface.
 Similar to the Java compiler, the type is not required to have the
 FunctionalInterface annotation to be treated as a functional interface.
-For example a Kava Function can be called directly without using the accept method:
+For example a Java Function can be called directly without using the accept method:
 ::
     from java.util.function import Function
     identity = Function.identity()

--- a/src/main/c/Objects/pyjtype.c
+++ b/src/main/c/Objects/pyjtype.c
@@ -263,8 +263,8 @@ static int addMethods(JNIEnv* env, PyObject* dict, jclass clazz)
     }
     /**
      * If the clazz is an interface assume it is a functional interface until
-     * we find more than one abstract method. FunctionalInterfaces are
-     * automatically callable in Python.
+     * we find more than one abstract method or no abstract methods.
+     * FunctionalInterfaces are automatically callable in Python.
      */
     jboolean functionalInterface = java_lang_Class_isInterface(env, clazz);
     if (process_java_exception(env)) {
@@ -296,6 +296,11 @@ static int addMethods(JNIEnv* env, PyObject* dict, jclass clazz)
             }
             if (isAbstract) {
                 if (oneAbstractPyJMethod) {
+                    /*
+		     * If there is already one abstract method and this method is also
+		     * abstract then this isn't a functional interface and there is no need
+		     * to keep track of abstract methods.
+		     */
                     functionalInterface = JNI_FALSE;
                     oneAbstractPyJMethod = NULL;
                 } else {

--- a/src/test/python/test_types.py
+++ b/src/test/python/test_types.py
@@ -921,3 +921,16 @@ class TestTypes(unittest.TestCase):
         except ImportError:
             pass # not built with numpy
 
+    def test_function_is_callable(self):
+        from java.util.function import Function
+        identity = Function.identity()
+        # identity is a PyJType of java.util.function.Function so it has an apply method
+        self.assertEqual("test", identity.apply("test"))
+        # All Functions are automatically callable so it can be called directly instead of applied
+        self.assertEqual("test", identity("test"))
+        # Make a slightly more complicate Function by converting int to a Function run after identity
+        intAsJavaFunction = identity.andThen(int)
+        # Even though all the logic is in Python it is still a java Function and can accept
+        self.assertEqual(123, intAsJavaFunction.apply("123"))
+        # But it is also callable
+        self.assertEqual(123, intAsJavaFunction("123"))


### PR DESCRIPTION
In Jep 3.7 we made it so that Python Callables can be converted to FunctionalInterfaces when passed to Java so I think it is appropriate to do the inverse when passing a FunctionalInterface to Python.