### PR TITLE
Adapt code to setuptools.dep_util deprecation.

### DIFF
--- a/commands/java.py
+++ b/commands/java.py
@@ -1,5 +1,8 @@
 from setuptools import Command
-from setuptools.dep_util import newer_group
+try:
+    from setuptools.modified import newer_group
+except ImportError:
+    from setuptools.dep_util import newer_group
 
 import shutil
 import os

--- a/commands/scripts.py
+++ b/commands/scripts.py
@@ -11,7 +11,10 @@ import sysconfig
 
 from stat import ST_MODE
 from setuptools import Command
-from distutils.dep_util import newer
+try:
+    from setuptools.modified import newer
+except ImportError:
+    from distutils.dep_util import newer
 from commands.util import is_osx
 from commands.util import is_windows
 from commands.python import get_libpython


### PR DESCRIPTION
Installation of jep is broken with the recent deprecation of `setuptools.dep_util` in favor of `modified` (see https://github.com/pypa/setuptools/commit/0296279b68c7a29dbafd62f5c2d96220767bb4b6).

Tested with:
- [x] python 3.10
- [x] python 3.11
- [x] python 3.12