### PR TITLE
Support for isolated SubInterpreter

### DIFF
--- a/release_notes/4.2-notes.rst
+++ b/release_notes/4.2-notes.rst
@@ -66,3 +66,15 @@ called from Python using both varargs and kwargs:
         // do stuff
     }
 
+Support for isolated SubInterpreter
+***********************************
+When using Python 3.12 or greater it is now possible to created isolated
+SubInterpreters which have separate GILs to improve concurrency. This feature
+can be enabled by setting the 
+`SubInterpreterOptions <https://ninia.github.io/jep/javadoc/4.2/jep/SubInterpreterOptions.html>`_
+on
+`JepConfig <https://ninia.github.io/jep/javadoc/4.2/jep/JepConfig.html>`_
+to SubInterpreterOptions.isolated(). For more details about how
+isolated sub-interpreters are different from ordinary interpreters refer to
+`PEP-684 <https://peps.python.org/pep-0684/>`_
+

--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -49,7 +49,8 @@ void pyembed_startup(JNIEnv*, jobjectArray);
 void pyembed_shutdown(JavaVM*);
 void pyembed_shared_import(JNIEnv*, jstring);
 
-intptr_t pyembed_thread_init(JNIEnv*, jobject, jobject, jboolean, jboolean);
+intptr_t pyembed_thread_init(JNIEnv*, jobject, jobject, jboolean, jboolean,
+                             jboolean, jint, jint, jint, jint, jint, jint, jint);
 void pyembed_thread_close(JNIEnv*, intptr_t);
 
 void pyembed_close(void);

--- a/src/main/c/Jep/jep.c
+++ b/src/main/c/Jep/jep.c
@@ -65,9 +65,14 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
  */
 JNIEXPORT jlong JNICALL Java_jep_Jep_init
 (JNIEnv *env, jobject obj, jobject cl, jboolean hasSharedModules,
- jboolean usesubinterpreter)
+ jboolean usesubinterpreter, jboolean isolated, jint useMainObmalloc,
+ jint allowFork, jint allowExec, jint allowThreads,
+ jint allowDaemonThreads, jint checkMultiInterpExtensions, jint ownGIL)
 {
-    return pyembed_thread_init(env, cl, obj, hasSharedModules, usesubinterpreter);
+    return pyembed_thread_init(env, cl, obj, hasSharedModules, usesubinterpreter,
+                               isolated, useMainObmalloc, allowFork, allowExec,
+                               allowThreads, allowDaemonThreads,
+                               checkMultiInterpExtensions, ownGIL);
 }
 
 

--- a/src/main/java/jep/JepConfig.java
+++ b/src/main/java/jep/JepConfig.java
@@ -58,6 +58,8 @@ public class JepConfig {
 
     protected Set<String> sharedModules = null;
 
+    protected SubInterpreterOptions subInterpOptions = SubInterpreterOptions.legacy();
+
     /**
      * Sets a path of directories separated by File.pathSeparator that will be
      * appended to the sub-intepreter's <code>sys.path</code>
@@ -158,6 +160,10 @@ public class JepConfig {
      * that use the c-api. For a complete discussion of the types of problems
      * that can require shared modules see the documentation on
      * shared_modules_hook.py.
+     *
+     * Note that shared modules cannot be used in a sub-interpreter that has its
+     * own allocation state which also means shared modules cannot be used in a
+     * sub-interpreter with its own GIL.
      * 
      * @param sharedModules
      *            a set of module names that should be shared
@@ -189,10 +195,26 @@ public class JepConfig {
     }
 
     /**
+     * Set the configuration options for a sub-interpreter. These options
+     * are only used in Python version 3.12 or later, when using earlier versions
+     * of Python these options are ignored. These options are only used for SubInterpreter
+     * and should not be set when configuring SharedInterpreter.
+     *
+     * @param subInterpOptions
+     *            the sub-interpreter options
+     * @return a reference to this JepConfig
+     * 
+     * @since 4.2
+     */
+    public JepConfig setSubInterpreterOptions(SubInterpreterOptions subInterpOptions) {
+        this.subInterpOptions = subInterpOptions;
+        return this;
+    }
+
+    /**
      * Creates a new Jep instance and its associated sub-interpreter with this
      * JepConfig.
      * 
-     * @return a new SubInterpreter instance
      * @throws JepException
      *             if an error occurs
      * @since 3.9

--- a/src/main/java/jep/SubInterpreterOptions.java
+++ b/src/main/java/jep/SubInterpreterOptions.java
@@ -61,9 +61,9 @@ public class SubInterpreterOptions {
      * allocator state. Otherwise it will use (share) the main interpreter’s.
      * 
      * If this is false then check_multi_interp_extensions must be true. If this
-     * is true then gil must not be true.
+     * is true then own GIL must not be true.
      *
-     * Shared Modules cannot be used when this is set to true.
+     * Shared Modules cannot be used when this is set to false.
      *
      * @param useMainObmalloc
      *            whether the sub-interpreter will share the main interpreter's
@@ -77,8 +77,8 @@ public class SubInterpreterOptions {
     }
 
     /**
-     * If this is 0 then the runtime will not support forking the process in
-     * any thread where the sub-interpreter is currently active. Otherwise
+     * If this is false then the runtime will not support forking the process
+     * in any thread where the sub-interpreter is currently active. Otherwise
      * fork is unrestricted.
      *
      * Note that the subprocess module still works when fork is disallowed.
@@ -111,8 +111,8 @@ public class SubInterpreterOptions {
     }
 
     /**
-     * If this is false then the sub-interpreter’s threading module won’t
-     * create threads. Otherwise threads are allowed.
+     * If this is false then the sub-interpreter’s threading module won’t be
+     * able to create threads. Otherwise threads are allowed.
      *
      * @param allowThreads
      *            whether the  sub-interpreter will allow threads.
@@ -125,8 +125,8 @@ public class SubInterpreterOptions {
     }
 
     /**
-     * If this is false then the sub-interpreter’s threading module won’t
-     * create daemon threads. Otherwise daemon threads are allowed 
+     * If this is false then the sub-interpreter’s threading module won’t be
+     * able to create daemon threads. Otherwise daemon threads are allowed 
      * (as long as allowThreads is true).
      *
      * @param allowDaemonThreads
@@ -165,7 +165,7 @@ public class SubInterpreterOptions {
      * If this is true then useMainObmalloc must be false.
      *
      * @param ownGIL
-     *            whether the  sub-interpreter will use its own GIL.
+     *            whether the sub-interpreter will use its own GIL.
      * @return a reference to this SubInterpreterOptions
      *
      */

--- a/src/main/java/jep/SubInterpreterOptions.java
+++ b/src/main/java/jep/SubInterpreterOptions.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2023 JEP AUTHORS.
+ *
+ * This file is licensed under the the zlib/libpng License.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any
+ * damages arising from the use of this software.
+ * 
+ * Permission is granted to anyone to use this software for any
+ * purpose, including commercial applications, and to alter it and
+ * redistribute it freely, subject to the following restrictions:
+ * 
+ *     1. The origin of this software must not be misrepresented; you
+ *     must not claim that you wrote the original software. If you use
+ *     this software in a product, an acknowledgment in the product
+ *     documentation would be appreciated but is not required.
+ * 
+ *     2. Altered source versions must be plainly marked as such, and
+ *     must not be misrepresented as being the original software.
+ * 
+ *     3. This notice may not be removed or altered from any source
+ *     distribution.
+ */
+package jep;
+
+/**
+ * A configuration object containing additional options for constructing a SubInterpreter.
+ *
+ * These options map directly to the options documented at
+ * https://docs.python.org/3/c-api/init.html#c.PyInterpreterConfig.
+ * 
+ * These options are ignored if a Python version earlier than 3.12 is used with Jep.
+ *
+ * @since 4.2
+ */
+public class SubInterpreterOptions {
+
+    protected boolean isolated;
+
+    protected int useMainObmalloc = -1;
+
+    protected int allowFork = -1;
+
+    protected int allowExec = -1;
+
+    protected int allowThreads = -1;
+
+    protected int allowDaemonThreads = -1;
+
+    protected int checkMultiInterpeExtensions = -1;
+
+    protected int ownGIL = -1;
+
+    protected SubInterpreterOptions(boolean isolated){
+        this.isolated = isolated;
+    }
+
+    /**
+     * If this is false then the sub-interpreter will use its own "object"
+     * allocator state. Otherwise it will use (share) the main interpreter’s.
+     * 
+     * If this is false then check_multi_interp_extensions must be true. If this
+     * is true then gil must not be true.
+     *
+     * Shared Modules cannot be used when this is set to true.
+     *
+     * @param useMainObmalloc
+     *            whether the sub-interpreter will share the main interpreter's
+     *            allocator state.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setUseMainObmalloc(boolean useMainObmalloc) {
+        this.useMainObmalloc = useMainObmalloc ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * If this is 0 then the runtime will not support forking the process in
+     * any thread where the sub-interpreter is currently active. Otherwise
+     * fork is unrestricted.
+     *
+     * Note that the subprocess module still works when fork is disallowed.
+     *
+     * @param allowFork
+     *            whether the  sub-interpreter will allow fork.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setAllowFork(boolean allowFork) {
+        this.allowFork = allowFork ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * If this is false then the runtime will not support replacing the current
+     * process via exec (e.g. os.execv()) in any thread where the
+     * sub-interpreter is currently active. Otherwise exec is unrestricted.
+     *
+     * Note that the subprocess module still works when exec is disallowed.
+     *
+     * @param allowExec
+     *            whether the  sub-interpreter will allow exec.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setAllowExec(boolean allowExec) {
+        this.allowExec = allowExec ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * If this is false then the sub-interpreter’s threading module won’t
+     * create threads. Otherwise threads are allowed.
+     *
+     * @param allowThreads
+     *            whether the  sub-interpreter will allow threads.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setAllowThreads(boolean allowThreads) {
+        this.allowThreads = allowThreads ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * If this is false then the sub-interpreter’s threading module won’t
+     * create daemon threads. Otherwise daemon threads are allowed 
+     * (as long as allowThreads is true).
+     *
+     * @param allowDaemonThreads
+     *            whether the  sub-interpreter will allow daemon threads.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setAllowDaemonThreads(boolean allowDaemonThreads) {
+        this.allowDaemonThreads = allowDaemonThreads ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * If this is false then all extension modules may be imported, including
+     * legacy (single-phase init) modules, in any thread where the
+     * sub-interpreter is currently active. Otherwise only multi-phase init
+     * extension modules (see PEP 489) may be imported.
+     *
+     * This must be true if useMainObmalloc is false.
+     *
+     * @param checkMultiInterpeExtensions
+     *            whether the  sub-interpreter will restrict import of legacy modules
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setCheckMultiInterpeExtensions(boolean checkMultiInterpeExtensions) {
+        this.checkMultiInterpeExtensions = checkMultiInterpeExtensions ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * This determines the operation of the GIL for the sub-interpreter. When
+     * this is false use (share) the main interpreter’s GIL. When this is true
+     * use the sub-interpreter’s own GIL.
+     *
+     * If this is true then useMainObmalloc must be false.
+     *
+     * @param ownGIL
+     *            whether the  sub-interpreter will use its own GIL.
+     * @return a reference to this SubInterpreterOptions
+     *
+     */
+    public SubInterpreterOptions setOwnGIL(boolean ownGIL) {
+        this.ownGIL = ownGIL ? 1 : 0;
+        return this;
+    }
+
+    /**
+     * Create a new SubInterpreterOptions with the default legacy settings.
+     * All settings can be changed using the setters in this class.
+     */
+    public static SubInterpreterOptions legacy() {
+        return new SubInterpreterOptions(false);
+    }
+
+    /**
+     * Create a new SubInterpreterOptions with the default isolated settings.
+     * Using these settings eliminates GIL contention but may not be compatible
+     * with all third party modules. These settings are not compatible with
+     * shared modules. All settings can be changed using the setters in this class.
+     */
+    public static SubInterpreterOptions isolated() {
+        return new SubInterpreterOptions(true);
+    }
+
+}

--- a/src/test/java/jep/test/TestSubInterpOptions.java
+++ b/src/test/java/jep/test/TestSubInterpOptions.java
@@ -1,0 +1,124 @@
+package jep.test;
+
+import jep.Interpreter;
+import jep.JepConfig;
+import jep.JepException;
+import jep.SubInterpreter;
+import jep.SubInterpreterOptions;
+
+public class TestSubInterpOptions {
+
+    /* Set to a non-null value to fail the test */
+    private String failure;
+
+    public boolean testForbidFork() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowFork(false);
+        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            interp.exec("import os");
+            interp.exec("os.fork()");
+            failure = "Fork should not be allowed";
+            return false;
+        } catch (JepException e) {
+            if (e.getMessage().contains("fork not supported for isolated subinterpreters")) {
+                return true;
+            }
+            failure = e.getMessage();
+            return false;
+        }
+    }
+
+    public boolean testForbidExec() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowExec(false);
+        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            interp.exec("import os");
+            interp.exec("os.execv('/bin/ls', [])");
+            failure = "Exec should not be allowed";
+            return false;
+        } catch (JepException e) {
+            if (e.getMessage().contains("exec not supported for isolated subinterpreters")) {
+                return true;
+            }
+            failure = e.getMessage();
+            return false;
+        }
+    }
+
+    public boolean testForbidThreads() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowThreads(false);
+        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            interp.exec("import threading");
+            interp.exec("threading.Thread(target=print).start()");
+            failure = "Thread should not be allowed";
+            return false;
+        } catch (JepException e) {
+            if (e.getMessage().contains("thread is not supported for isolated subinterpreters")) {
+                return true;
+            }
+            failure = e.getMessage();
+            return false;
+        }
+    }
+
+    public boolean testForbidDaemonThreads() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowDaemonThreads(false);
+        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            interp.exec("import threading");
+            interp.exec("threading.Thread(target=print, daemon=True).start()");
+            failure = "Daemon Thread should not be allowed";
+            return false;
+        } catch (JepException e) {
+            if (e.getMessage().contains("daemon threads are disabled in this (sub)interpreter")) {
+                return true;
+            }
+            failure = e.getMessage();
+            return false;
+        }
+    }
+
+    public boolean testIsolated() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.isolated();
+        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            interp.exec("from java.lang import Object");
+            // I have no way to check if the interpreter is actually isolated so
+            // for now just assume it is OK if it is running and trust the API
+            return true;
+        } catch (JepException e) {
+            failure = e.getMessage();
+	    System.out.println(failure);
+            return false;
+        }
+    }
+
+    public void runTest() {
+        if (!testForbidFork()) {
+            return;
+        }
+        if (!testForbidExec()) {
+            return;
+        }
+        if (!testForbidThreads()) {
+            return;
+        }
+        if (!testForbidDaemonThreads()) {
+            return;
+        }
+        if (!testIsolated()) {
+            return;
+        }
+    }
+
+    public static String test() throws InterruptedException{
+        TestSubInterpOptions test = new TestSubInterpOptions();
+        Thread t = new Thread(test::runTest);
+        t.start();
+        t.join();
+        return test.failure;
+    }
+
+
+}

--- a/src/test/python/test_sub_interp_options.py
+++ b/src/test/python/test_sub_interp_options.py
@@ -1,0 +1,12 @@
+import unittest
+import jep
+import sys
+
+TestSubInterpOptionsJava = jep.findClass('jep.test.TestSubInterpOptions')
+
+class TestSubInterpOptions(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info.major == 3 and sys.version_info.minor < 12,
+            "SubInterpreterOptions not supported before Python 3.12")
+    def test_sub_interp_options(self):
+        self.assertEqual(None, TestSubInterpOptionsJava.test())


### PR DESCRIPTION
When using Python 3.12 or greater it is now possible to created isolated SubInterpreters which have separate GILs to improve concurrency. This feature can be enabled by setting the SubInterpreterOptions on JepConfig to SubInterpreterOptions.isolated(). For more details about how isolated sub-interpreters are different from ordinary interpreters refer to PEP-684.