### PR TITLE
Fix leaking attributes in java PyObject.

### DIFF
--- a/src/main/c/Jep/python/jep_object.c
+++ b/src/main/c/Jep/python/jep_object.c
@@ -109,12 +109,12 @@ JNIEXPORT void JNICALL Java_jep_python_PyObject_setAttr
         goto EXIT;
     }
     ret = PyObject_SetAttrString(pyObject, attrName, pyAttr);
-    Py_DECREF(pyAttr);
     if (ret == -1) {
         process_py_exception(env);
     }
 
 EXIT:
+    Py_XDECREF(pyAttr);
     PyEval_ReleaseThread(jepThread->tstate);
     release_utf_char(env, str, attrName);
 }

--- a/src/main/c/Jep/python/jep_object.c
+++ b/src/main/c/Jep/python/jep_object.c
@@ -109,6 +109,7 @@ JNIEXPORT void JNICALL Java_jep_python_PyObject_setAttr
         goto EXIT;
     }
     ret = PyObject_SetAttrString(pyObject, attrName, pyAttr);
+    Py_DECREF(pyAttr);
     if (ret == -1) {
         process_py_exception(env);
     }


### PR DESCRIPTION
This is a fix for the problem identified in #538.