### PR TITLE
Run Python garbage collector when an interpreter is closed.

### DIFF
--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -703,6 +703,7 @@ void pyembed_thread_close(JNIEnv *env, intptr_t _jepThread)
     Py_DECREF(key);
 
     Py_CLEAR(jepThread->globals);
+    PyGC_Collect();
 
     if (jepThread->classloader) {
         (*env)->DeleteGlobalRef(env, jepThread->classloader);


### PR DESCRIPTION
This change will run Python Garbage Collection anytime an interpreter is closed.

#555 describes a simple use case where reference counting alone is unable to free memory in a jep interpreter on close and running the garbage collector cleans up the memory.

There is a potential downside that this will make close slower in some cases however it should be negligible in most cases and I believe the benefit of freeing memory promptly is worth the extra time in close().