### PR TITLE
override toString() on JepConfig, PyConfig, and SubInterpreterOptions

### DIFF
--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -160,7 +160,7 @@ public abstract class Jep implements Interpreter {
         SubInterpreterOptions interpOptions = config.subInterpOptions;
         this.tstate = init(this.classLoader, hasSharedModules,
                 useSubInterpreter, interpOptions.isolated,
-		interpOptions.useMainObmalloc,
+                interpOptions.useMainObmalloc,
                 interpOptions.allowFork, interpOptions.allowExec,
                 interpOptions.allowThreads, interpOptions.allowDaemonThreads,
                 interpOptions.checkMultiInterpeExtensions,

--- a/src/main/java/jep/JepConfig.java
+++ b/src/main/java/jep/JepConfig.java
@@ -223,4 +223,14 @@ public class JepConfig {
         return new SubInterpreter(this);
     }
 
+    @Override
+    public String toString() {
+        return "JepConfig [interactive=" + interactive + ", includePath="
+                + includePath + ", classLoader=" + classLoader
+                + ", classEnquirer=" + classEnquirer + ", redirectStdout="
+                + redirectStdout + ", redirectStderr=" + redirectStderr
+                + ", sharedModules=" + sharedModules + ", subInterpOptions="
+                + subInterpOptions + "]";
+    }
+
 }

--- a/src/main/java/jep/PyConfig.java
+++ b/src/main/java/jep/PyConfig.java
@@ -35,6 +35,12 @@ package jep;
  */
 public class PyConfig {
 
+    /*
+     * -1 is used to indicate not set, in which case we will not set it in
+     * the native code and the setting will be Python's default. A value of 0
+     * or greater will cause the value to be set in the native code.
+     */
+
     protected int noSiteFlag = -1;
 
     protected int noUserSiteDirectory = -1;
@@ -161,5 +167,16 @@ public class PyConfig {
         this.pythonHome = pythonHome;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "PyConfig [noSiteFlag=" + noSiteFlag + ", noUserSiteDirectory="
+                + noUserSiteDirectory + ", ignoreEnvironmentFlag="
+                + ignoreEnvironmentFlag + ", verboseFlag=" + verboseFlag
+                + ", optimizeFlag=" + optimizeFlag + ", dontWriteBytecodeFlag="
+                + dontWriteBytecodeFlag + ", hashRandomizationFlag="
+                + hashRandomizationFlag + ", pythonHome=" + pythonHome + "]";
+    }
+
 
 }

--- a/src/main/java/jep/SubInterpreterOptions.java
+++ b/src/main/java/jep/SubInterpreterOptions.java
@@ -36,6 +36,12 @@ package jep;
  */
 public class SubInterpreterOptions {
 
+    /*
+     * -1 is used to indicate not set, in which case we will not set it in
+     * the native code and the setting will be Python's default. A value of 0
+     * or 1 will cause the value to be set in the native code.
+     */
+
     protected boolean isolated;
 
     protected int useMainObmalloc = -1;
@@ -190,6 +196,16 @@ public class SubInterpreterOptions {
      */
     public static SubInterpreterOptions isolated() {
         return new SubInterpreterOptions(true);
+    }
+
+    @Override
+    public String toString() {
+        return "SubInterpreterOptions [isolated=" + isolated
+                + ", useMainObmalloc=" + useMainObmalloc + ", allowFork="
+                + allowFork + ", allowExec=" + allowExec + ", allowThreads="
+                + allowThreads + ", allowDaemonThreads=" + allowDaemonThreads
+                + ", checkMultiInterpeExtensions=" + checkMultiInterpeExtensions
+                + ", ownGIL=" + ownGIL + "]";
     }
 
 }


### PR DESCRIPTION
Override toString() on JepConfig, PyConfig, and SubInterpreterOptions