### PR TITLE
Test numpy in shared interpreter.

### DIFF
--- a/src/test/java/jep/test/numpy/TestNumpy.java
+++ b/src/test/java/jep/test/numpy/TestNumpy.java
@@ -7,7 +7,7 @@ import jep.Interpreter;
 import jep.JepConfig;
 import jep.JepException;
 import jep.NDArray;
-import jep.SubInterpreter;
+import jep.SharedInterpreter;
 import jep.python.PyObject;
 
 /**
@@ -311,8 +311,8 @@ public class TestNumpy {
     }
 
     public static void main(String[] args) {
-        try (Interpreter interp = new SubInterpreter(
-                new JepConfig().addIncludePaths("."))) {
+        SharedInterpreter.setConfig(new JepConfig().addIncludePaths("."));
+        try (Interpreter interp = new SharedInterpreter()) {
             TestNumpy test = new TestNumpy();
             test.testNDArraySafety();
             test.testSetAndGet(interp);


### PR DESCRIPTION
When testing compatibility with Python 3.13 the numpy tests were failing with the error "RuntimeError: CPU dispatcher tracer already initlized" from the numpy code [here](https://github.com/numpy/numpy/blob/v2.1.2/numpy/_core/src/common/npy_cpu_dispatch.c#L12). I am not sure why this is showing up in Python 3.13 and not earlier versions but since numpy does not support sub-interpreters I think it is best that our tests use a SharedInterpreter instead, which allows the test to pass for all python versions.