### PR TITLE
Skip new test on python 3.6.

### DIFF
--- a/src/test/python/test_allow_python_enquirer.py
+++ b/src/test/python/test_allow_python_enquirer.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from jep_pipe import jep_pipe
@@ -5,5 +6,7 @@ from jep_pipe import build_java_process_cmd
 
 class TestAllowPythonEnquirer(unittest.TestCase):
 
+    @unittest.skipIf(sys.version_info.major == 3 and sys.version_info.minor < 7,
+            "Test needs re.Pattern which was added in Python 3.7")
     def test_allow_python_enquirer(self):
         jep_pipe(build_java_process_cmd('jep.test.TestAllowPythonEnquirer'))


### PR DESCRIPTION
While doing some final testing for the 4.2.1 release I found the new test for the AllowPythonEnquirer does not work on Python3.6. It looks like this is just because the test relies on `re.Pattern` which was new in Python3.7. The failing test does not actually indicate that the AllowPythonEnquirer is broken on Python3.6.

We barely support Python3.6 but I don't want to drop support for a Python version in a patch release. I also know @ndjensen had difficulty finding standard libraries that would work in test this so I don't want to put effort into redoing the test just for an ancient Python version. I am proposing we just skip this test on Python3.6 and we can stop supporting Python3.6 when we do jep 4.3.