### PR TITLE
Add configuration for setting program name.

### DIFF
--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -44,7 +44,7 @@ typedef struct __JepThread JepThread;
 
 
 void pyembed_preinit(JNIEnv*, jint, jint, jint, jint, jint, jint, jint,
-                     jstring);
+                     jstring, jstring);
 void pyembed_startup(JNIEnv*, jobjectArray);
 void pyembed_shutdown(JavaVM*);
 void pyembed_shared_import(JNIEnv*, jstring);

--- a/src/main/c/Jep/maininterpreter.c
+++ b/src/main/c/Jep/maininterpreter.c
@@ -47,11 +47,12 @@ JNIEXPORT void JNICALL Java_jep_MainInterpreter_setInitParams
  jint optimizeFlag,
  jint dontWriteBytecodeFlag,
  jint hashRandomizationFlag,
- jstring pythonHome)
+ jstring pythonHome,
+ jstring programName)
 {
     pyembed_preinit(env, noSiteFlag, noUserSiteDirectory, ignoreEnvironmentFlag,
                     verboseFlag, optimizeFlag, dontWriteBytecodeFlag,
-                    hashRandomizationFlag, pythonHome);
+                    hashRandomizationFlag, pythonHome, programName);
 }
 
 /*

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -239,7 +239,8 @@ void pyembed_preinit(JNIEnv *env,
                      jint optimizeFlag,
                      jint dontWriteBytecodeFlag,
                      jint hashRandomizationFlag,
-                     jstring pythonHome)
+                     jstring pythonHome,
+                     jstring programName)
 {
     if (noSiteFlag >= 0) {
         Py_NoSiteFlag = noSiteFlag;
@@ -267,6 +268,14 @@ void pyembed_preinit(JNIEnv *env,
         wchar_t* homeForPython = Py_DecodeLocale(homeAsUTF, NULL);
         (*env)->ReleaseStringUTFChars(env, pythonHome, homeAsUTF);
         Py_SetPythonHome(homeForPython);
+        // Python documentation says that the string should not be changed for
+        // the duration of the program so it can never be freed.
+    }
+    if (programName) {
+        const char* nameAsUTF = (*env)->GetStringUTFChars(env, programName, NULL);
+        wchar_t* nameForPython = Py_DecodeLocale(nameAsUTF, NULL);
+        (*env)->ReleaseStringUTFChars(env, programName, nameAsUTF);
+        Py_SetProgramName(nameForPython);
         // Python documentation says that the string should not be changed for
         // the duration of the program so it can never be freed.
     }
@@ -561,7 +570,7 @@ void pyembed_shared_import(JNIEnv *env, jstring module)
 intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
                              jboolean hasSharedModules, jboolean usesubinterpreter,
                              jboolean isolated, jint useMainObmalloc, jint allowFork,
-			     jint allowExec, jint allowThreads, jint allowDaemonThreads,
+                             jint allowExec, jint allowThreads, jint allowDaemonThreads,
                              jint checkMultiInterpExtensions, jint ownGIL)
 {
     JepThread *jepThread;
@@ -587,8 +596,8 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
         PyEval_AcquireThread(mainThreadState);
 
 #if PY_MAJOR_VERSION > 3 || PY_MINOR_VERSION >= 12
-        PyInterpreterConfig config; 
-	if (isolated) {
+        PyInterpreterConfig config;
+        if (isolated) {
             config = (PyInterpreterConfig) _PyInterpreterConfig_INIT;
         } else {
             config = (PyInterpreterConfig) _PyInterpreterConfig_LEGACY_INIT;

--- a/src/main/java/jep/MainInterpreter.java
+++ b/src/main/java/jep/MainInterpreter.java
@@ -138,7 +138,7 @@ public final class MainInterpreter implements AutoCloseable {
             setInitParams(pyConfig.noSiteFlag, pyConfig.noUserSiteDirectory,
                     pyConfig.ignoreEnvironmentFlag, pyConfig.verboseFlag,
                     pyConfig.optimizeFlag, pyConfig.dontWriteBytecodeFlag,
-                    pyConfig.hashRandomizationFlag, pyConfig.pythonHome);
+                    pyConfig.hashRandomizationFlag, pyConfig.pythonHome, pyConfig.programName);
         }
 
         thread = new Thread("JepMainInterpreter") {
@@ -293,7 +293,7 @@ public final class MainInterpreter implements AutoCloseable {
     private static native void setInitParams(int noSiteFlag,
             int noUserSiteDiretory, int ignoreEnvironmentFlag, int verboseFlag,
             int optimizeFlag, int dontWriteBytecodeFlag,
-            int hashRandomizationFlag, String pythonHome);
+            int hashRandomizationFlag, String pythonHome, String programName);
 
     private static native void initializePython(String[] mainInterpreterArgv);
 

--- a/src/main/java/jep/PyConfig.java
+++ b/src/main/java/jep/PyConfig.java
@@ -36,9 +36,9 @@ package jep;
 public class PyConfig {
 
     /*
-     * -1 is used to indicate not set, in which case we will not set it in
-     * the native code and the setting will be Python's default. A value of 0
-     * or greater will cause the value to be set in the native code.
+     * -1 is used to indicate not set, in which case we will not set it in the
+     * native code and the setting will be Python's default. A value of 0 or
+     * greater will cause the value to be set in the native code.
      */
 
     protected int noSiteFlag = -1;
@@ -56,6 +56,8 @@ public class PyConfig {
     protected int hashRandomizationFlag = -1;
 
     protected String pythonHome;
+
+    protected String programName;
 
     /**
      * Set the Py_NoSiteFlag variable on the python interpreter. This
@@ -155,7 +157,7 @@ public class PyConfig {
     }
 
     /**
-     * Set the home location on the python interpreter. THis is the location of
+     * Set the home location on the python interpreter. This is the location of
      * the standard python libraries. This corresponds to the environment
      * variable PYTHONHOME.
      * 
@@ -168,15 +170,27 @@ public class PyConfig {
         return this;
     }
 
-    @Override
-    public String toString() {
-        return "PyConfig [noSiteFlag=" + noSiteFlag + ", noUserSiteDirectory="
-                + noUserSiteDirectory + ", ignoreEnvironmentFlag="
-                + ignoreEnvironmentFlag + ", verboseFlag=" + verboseFlag
-                + ", optimizeFlag=" + optimizeFlag + ", dontWriteBytecodeFlag="
-                + dontWriteBytecodeFlag + ", hashRandomizationFlag="
-                + hashRandomizationFlag + ", pythonHome=" + pythonHome + "]";
+    /**
+     * Set the Py_SetProgramName variable on the python interpreter. This is
+     * used to initialize executable and in early error messages during python
+     * initialization.
+     * 
+     * @param programName
+     *            the name of the executable python program.
+     * @return a reference to this PyConfig
+     */
+    public PyConfig setProgramName(String programName) {
+        this.programName = programName;
+        return this;
     }
 
+    @Override
+    public String toString() {
+        return "PyConfig [noSiteFlag=" + noSiteFlag + ", noUserSiteDirectory=" + noUserSiteDirectory
+                + ", ignoreEnvironmentFlag=" + ignoreEnvironmentFlag + ", verboseFlag=" + verboseFlag
+                + ", optimizeFlag=" + optimizeFlag + ", dontWriteBytecodeFlag=" + dontWriteBytecodeFlag
+                + ", hashRandomizationFlag=" + hashRandomizationFlag + ", pythonHome=" + pythonHome + ", programName="
+                + programName + "]";
+    }
 
 }


### PR DESCRIPTION
This will resolve #515 and when investigating #572 I found it also makes it easier to configure python on Mac without setting env vars.