### PR TITLE
Recommend disabling pip caching during installation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,11 @@ Some benefits of embedding CPython in a JVM:
 
 Installation
 ------------
-Simply run ``pip install jep`` or download the source and run ``pip install .``.
+Simply run ``pip install --no-cache-dir jep`` or download the source and run ``pip install .``.
 Building and installing require the JDK, Python, and optionally numpy to be installed beforehand.
+The ``--no-cache-dir`` option is not strictly required, however Jep includes settings from your
+environment in the build so it is important to avoid caching if rebuilding with any changes to 
+your environment such as changing the venv or installing/removing numpy.
 
 Dependencies
 ------------


### PR DESCRIPTION
We have had issues in the past with people having trouble enabling dumpy due to the pip cache and recently also had a report of inaccurate info in the jep script because of the same cache. This updates the readme to recommend disabling the cache to avoid these problems.