### PR TITLE
Fix ClassList to handle jar in working dir with classpath in manifest.

### DIFF
--- a/src/main/java/jep/ClassList.java
+++ b/src/main/java/jep/ClassList.java
@@ -127,8 +127,11 @@ public class ClassList implements ClassEnquirer {
                         String[] relativePaths = classpath.split(" ");
 
                         for (String relativePath : relativePaths) {
-                            String path = file.getParent() + File.separator
-                                    + relativePath;
+                            String path = relativePath;
+                            String parent = file.getParent();
+                            if (parent != null) {
+                                path = parent + File.separator + relativePath;
+                            }
                             if (!seen.contains(path)) {
                                 queue.add(path);
                                 seen.add(path);


### PR DESCRIPTION
This fixes #576 which would come up if your class path includes a jar in the current working directory that has a class path in the manifest. The manifest processing assumes every class path entry has a parent dir(lib/foo.jar) but if the jar is in the current working directory then class path entries may not have a parent dir(foo.jar).