### PR TITLE
Fix SubInterpreter pyjmethod leak on static types.

### DIFF
--- a/src/test/java/jep/test/util/SubInterpreterThread.java
+++ b/src/test/java/jep/test/util/SubInterpreterThread.java
@@ -1,0 +1,41 @@
+package jep.test.util;
+
+import jep.Interpreter;
+import jep.JepException;
+import jep.SubInterpreter;
+
+/**
+ * This is just a thread that runs some Python statements in a subinterpreter.
+ * It can be run from a Python unittest to verify SubInterpreter behavior
+ * without writing Java code.
+ */
+public class SubInterpreterThread extends Thread {
+
+    private final String[] pythonStatements;
+
+    private JepException exception;
+
+    public SubInterpreterThread(String... pythonStatements) {
+        this.pythonStatements = pythonStatements;
+    }
+
+    @Override
+    public void run() {
+        try (Interpreter interpreter = new SubInterpreter()) {
+            for (String statement : this.pythonStatements) {
+                interpreter.exec(statement);
+            }
+        } catch (JepException e) {
+            this.exception = e;
+        }
+    }
+
+    public boolean hasException() {
+        return exception != null;
+    }
+
+    public JepException getException() {
+        return exception;
+    }
+
+}

--- a/src/test/python/test_regressions.py
+++ b/src/test/python/test_regressions.py
@@ -35,3 +35,17 @@ class TestRegressions(unittest.TestCase):
         self.assertEqual('ParentClassWithMethod', ChildTestingMethodInheritance().checkPrecedence())
         ClassInheritingDefault = jep.findClass('jep.test.TestPyJType$ClassInheritingDefault')
         self.assertEqual('InterfaceWithDefault', ClassInheritingDefault().checkPrecedence())
+
+    def test_object_method_count(self):
+        # There was a bug where each new sub-interpreter would add all the
+        # Object methods onto multimethods on the Object type so the
+        # multimethod would grow with each new sub-interpreter.
+        from java.lang import Object
+        self.assertEqual(3, len(Object.wait.__methods__))
+        for i in range(3):
+            SubInterpreterThread = jep.findClass('jep.test.util.SubInterpreterThread')
+            thread = SubInterpreterThread();
+            thread.start();
+            thread.join();
+        from java.lang import Object
+        self.assertEqual(3, len(Object.wait.__methods__))


### PR DESCRIPTION
Each interpreter has a Python type corresponding to each Java class that has been used in that interpreter. Shared interpreters share a common collection of types but each sub-interpreter uses separate types to facilitate interpreters with different class loaders. Most types are dynamically allocated but the types for Object and Buffer are statically allocated because Buffer uses the python buffer protocol which is not available for dynamically allocated types in older versions of Python. 

During interpreter initialization PyJMethods are added to the Python types so that Java methods can be called from Python. The static types get the correct methods added when the first interpreter is initialized but any interpreter created after that adds redundant methods to the static types. In long running programs that create and close many sub-interpreters the extra redundant methods can cause memory problems because each PyJMethod is holding onto a JNI Global reference to a Java Method object.. The redundant methods can also slow down method calls if they are called from Python.

This change adds a static variable in the native code to ensure the methods are only added to the static types once.
