### PR TITLE
Add recommendation to build without isolation to enable numpy.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,12 @@ Some benefits of embedding CPython in a JVM:
 
 Installation
 ------------
-Simply run ``pip install --no-cache-dir jep`` or download the source and run ``pip install .``.
-Building and installing require the JDK, Python, and optionally numpy to be installed beforehand.
-The ``--no-cache-dir`` option is not strictly required, however Jep includes settings from your
-environment in the build so it is important to avoid caching if rebuilding with any changes to 
-your environment such as changing the venv or installing/removing numpy.
+Simply run ``pip install --no-cache-dir --no-build-isolation jep`` or download
+the source and run ``pip install .``. Building and installing require the JDK,
+Python, setuptools, and optionally numpy to be installed beforehand. The 
+``--no-cache-dir`` and ``--no-build-isolation` options are not strictly
+required, however those settings enable Jep to make customizations for your
+environment such as enabling numpy specific behavior if numpy is installed.
 
 Dependencies
 ------------


### PR DESCRIPTION
When building with Python 3.12 and 3.13 I am unable to build with numpy support using `pip install --no-cache-dir jep`. This was reported in #580. It seems pip is building in an isolated environment without numpy, even if numpy is installed which prevents setup.py from detecting numpy. I have been able to build with numpy support on all versions of Python using the `--no-build-isolation` so I am including that option in the command we recommend for installing jep.