### PR TITLE
Update PyConfig to align with PEP 587.

### DIFF
--- a/release_notes/4.3-notes.rst
+++ b/release_notes/4.3-notes.rst
@@ -2,3 +2,11 @@ Jep 4.3 Release Notes
 *********************
 This release drops support for versions of Python older than 3.10.
 
+Updates to PyConfig
+*******************
+`PyConfig <https://ninia.github.io/jep/javadoc/4.3/jep/PyConfig.html>`_ has
+been updated so that the API maps directly to the PyConfig structure in the
+Python C API which was introduced with
+`PEP 587 <https://peps.python.org/pep-0587/>`_. Most of the existing methods
+are now deprecated. The deprecated methods will continue to work as they did
+before for now but they will be removed in a future release.

--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -43,7 +43,7 @@ struct __JepThread {
 typedef struct __JepThread JepThread;
 
 
-void pyembed_startup(JNIEnv*, jobjectArray, jint, jint,jstring, jint, jstring,
+void pyembed_startup(JNIEnv*, jobjectArray, jint, jint, jstring, jint, jstring,
                      jint, jint, jint, jint, jint);
 void pyembed_shutdown(JavaVM*);
 void pyembed_shared_import(JNIEnv*, jstring);

--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -43,9 +43,8 @@ struct __JepThread {
 typedef struct __JepThread JepThread;
 
 
-void pyembed_preinit(JNIEnv*, jint, jint, jint, jint, jint, jint, jint,
-                     jstring, jstring);
-void pyembed_startup(JNIEnv*, jobjectArray);
+void pyembed_startup(JNIEnv*, jobjectArray, jint, jint,jstring, jint, jstring,
+                     jint, jint, jint, jint, jint);
 void pyembed_shutdown(JavaVM*);
 void pyembed_shared_import(JNIEnv*, jstring);
 

--- a/src/main/c/Jep/maininterpreter.c
+++ b/src/main/c/Jep/maininterpreter.c
@@ -34,36 +34,28 @@
 
 /*
  * Class:     jep_MainInterpreter
- * Method:    setInitParams
- * Signature: (IIIIIII)V
- */
-JNIEXPORT void JNICALL Java_jep_MainInterpreter_setInitParams
-(JNIEnv *env,
- jclass class,
- jint noSiteFlag,
- jint noUserSiteDirectory,
- jint ignoreEnvironmentFlag,
- jint verboseFlag,
- jint optimizeFlag,
- jint dontWriteBytecodeFlag,
- jint hashRandomizationFlag,
- jstring pythonHome,
- jstring programName)
-{
-    pyembed_preinit(env, noSiteFlag, noUserSiteDirectory, ignoreEnvironmentFlag,
-                    verboseFlag, optimizeFlag, dontWriteBytecodeFlag,
-                    hashRandomizationFlag, pythonHome, programName);
-}
-
-/*
- * Class:     jep_MainInterpreter
  * Method:    initializePython
- * Signature: ([Ljava/lang/String;)V
+ * Signature: ([Ljava/lang/String;IILjava/lang/String;ILjava/lang/String;IIIII)V
  */
 JNIEXPORT void JNICALL Java_jep_MainInterpreter_initializePython
-(JNIEnv *env, jclass class, jobjectArray argv)
+(JNIEnv *env,
+ jclass class,
+ jobjectArray argv,
+ jint hashSeed,
+ jint useHashSeed,
+ jstring home,
+ jint optimizationLevel,
+ jstring programName,
+ jint siteImport,
+ jint useEnvironment,
+ jint userSiteDirectory,
+ jint verbose,
+ jint writeByteCode
+)
 {
-    pyembed_startup(env, argv);
+    pyembed_startup(env, argv, hashSeed, useHashSeed, home, optimizationLevel,
+                    programName, siteImport, useEnvironment, userSiteDirectory, verbose,
+                    writeByteCode);
 }
 
 /*

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -337,6 +337,11 @@ void pyembed_startup(JNIEnv *env,
     PyStatus status = PyStatus_Ok();
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
+    // According to PEP-587 the fields shared with PyPreConfig should be set first.
+    config.parse_argv = 0;
+    if (useEnvironment >= 0) {
+        config.use_environment = useEnvironment;
+    }
 
     if (argv) {
         jsize count = (*env)->GetArrayLength(env, argv);
@@ -364,7 +369,6 @@ void pyembed_startup(JNIEnv *env,
         free(bytesArgv);
         (*env)->PopLocalFrame(env, NULL);
     }
-    config.parse_argv = 0;
     if (hashSeed >= 0) {
         config.hash_seed = hashSeed;
     }
@@ -386,9 +390,6 @@ void pyembed_startup(JNIEnv *env,
     }
     if (siteImport >= 0) {
         config.site_import = siteImport;
-    }
-    if (useEnvironment >= 0) {
-        config.use_environment = useEnvironment;
     }
     if (userSiteDirectory >= 0) {
         config.user_site_directory = userSiteDirectory;

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -231,56 +231,6 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
     return 0;
 }
 
-void pyembed_preinit(JNIEnv *env,
-                     jint noSiteFlag,
-                     jint noUserSiteDirectory,
-                     jint ignoreEnvironmentFlag,
-                     jint verboseFlag,
-                     jint optimizeFlag,
-                     jint dontWriteBytecodeFlag,
-                     jint hashRandomizationFlag,
-                     jstring pythonHome,
-                     jstring programName)
-{
-    if (noSiteFlag >= 0) {
-        Py_NoSiteFlag = noSiteFlag;
-    }
-    if (noUserSiteDirectory >= 0) {
-        Py_NoUserSiteDirectory = noUserSiteDirectory;
-    }
-    if (ignoreEnvironmentFlag >= 0) {
-        Py_IgnoreEnvironmentFlag = ignoreEnvironmentFlag;
-    }
-    if (verboseFlag >= 0) {
-        Py_VerboseFlag = verboseFlag;
-    }
-    if (optimizeFlag >= 0) {
-        Py_OptimizeFlag = optimizeFlag;
-    }
-    if (dontWriteBytecodeFlag >= 0) {
-        Py_DontWriteBytecodeFlag = dontWriteBytecodeFlag;
-    }
-    if (hashRandomizationFlag >= 0) {
-        Py_HashRandomizationFlag = hashRandomizationFlag;
-    }
-    if (pythonHome) {
-        const char* homeAsUTF = (*env)->GetStringUTFChars(env, pythonHome, NULL);
-        wchar_t* homeForPython = Py_DecodeLocale(homeAsUTF, NULL);
-        (*env)->ReleaseStringUTFChars(env, pythonHome, homeAsUTF);
-        Py_SetPythonHome(homeForPython);
-        // Python documentation says that the string should not be changed for
-        // the duration of the program so it can never be freed.
-    }
-    if (programName) {
-        const char* nameAsUTF = (*env)->GetStringUTFChars(env, programName, NULL);
-        wchar_t* nameForPython = Py_DecodeLocale(nameAsUTF, NULL);
-        (*env)->ReleaseStringUTFChars(env, programName, nameAsUTF);
-        Py_SetProgramName(nameForPython);
-        // Python documentation says that the string should not be changed for
-        // the duration of the program so it can never be freed.
-    }
-}
-
 /*
  * MSVC requires tp_base to be set at runtime instead of in the type
  * declaration. :/  Otherwise we could just set tp_base in the type declaration
@@ -316,7 +266,19 @@ static void handle_startup_exception(JNIEnv *env, const char* excMsg)
 }
 
 
-void pyembed_startup(JNIEnv *env, jobjectArray sharedModulesArgv)
+void pyembed_startup(JNIEnv *env,
+                     jobjectArray argv,
+                     jint hashSeed,
+                     jint useHashSeed,
+                     jstring home,
+                     jint optimizationLevel,
+                     jstring programName,
+                     jint siteImport,
+                     jint useEnvironment,
+                     jint userSiteDirectory,
+                     jint verbose,
+                     jint writeByteCode
+                    )
 {
     PyObject* sysModule       = NULL;
     PyObject* threadingModule = NULL;
@@ -372,7 +334,84 @@ void pyembed_startup(JNIEnv *env, jobjectArray sharedModulesArgv)
         return;
     }
 
-    Py_Initialize();
+    PyStatus status = PyStatus_Ok();
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+
+    if (argv) {
+        jsize count = (*env)->GetArrayLength(env, argv);
+        (*env)->PushLocalFrame(env, count * 2);
+        char** bytesArgv = (char**) malloc(count * sizeof(char**));
+        int i = 0;
+        for (i = 0; i < count; i++) {
+            jstring jarg = (*env)->GetObjectArrayElement(env, argv, i);
+            if (jarg == NULL) {
+                status = PyStatus_Error("Received null argv.");
+            } else {
+                char* arg = (char*) (*env)->GetStringUTFChars(env, jarg, NULL);
+                bytesArgv[i] = arg;
+            }
+        }
+        if (!PyStatus_Exception(status)) {
+            status = PyConfig_SetBytesArgv(&config, count, bytesArgv);
+        }
+        for (i = 0; i < count; i++) {
+            jstring jarg = (*env)->GetObjectArrayElement(env, argv, i);
+            if (jarg != NULL) {
+                (*env)->ReleaseStringUTFChars(env, jarg, bytesArgv[i]);
+            }
+        }
+        free(bytesArgv);
+        (*env)->PopLocalFrame(env, NULL);
+    }
+    config.parse_argv = 0;
+    if (hashSeed >= 0) {
+        config.hash_seed = hashSeed;
+    }
+    if (useHashSeed >= 0) {
+        config.use_hash_seed = useHashSeed;
+    }
+    if (!PyStatus_Exception(status) && home) {
+        const char* homeAsUTF = (*env)->GetStringUTFChars(env, home, NULL);
+        status = PyConfig_SetBytesString(&config, &config.home, homeAsUTF);
+        (*env)->ReleaseStringUTFChars(env, home, homeAsUTF);
+    }
+    if (optimizationLevel >= 0) {
+        config.optimization_level = optimizationLevel;
+    }
+    if (!PyStatus_Exception(status) && programName) {
+        const char* nameAsUTF = (*env)->GetStringUTFChars(env, programName, NULL);
+        status = PyConfig_SetBytesString(&config, &config.program_name, nameAsUTF);
+        (*env)->ReleaseStringUTFChars(env, programName, nameAsUTF);
+    }
+    if (siteImport >= 0) {
+        config.site_import = siteImport;
+    }
+    if (useEnvironment >= 0) {
+        config.use_environment = useEnvironment;
+    }
+    if (userSiteDirectory >= 0) {
+        config.user_site_directory = userSiteDirectory;
+    }
+    if (verbose >= 0) {
+        config.verbose = verbose;
+    }
+    if (writeByteCode >= 0) {
+        config.write_bytecode = writeByteCode;
+    }
+
+    if (!PyStatus_Exception(status)) {
+        status = Py_InitializeFromConfig(&config);
+    }
+    PyConfig_Clear(&config);
+    if (PyStatus_Exception(status)) {
+        jclass excClass = (*env)->FindClass(env, "java/lang/IllegalStateException");
+        if (excClass != NULL) {
+            (*env)->ThrowNew(env, excClass, status.err_msg);
+        }
+        // The exit code is ignored, because exiting seems rude.
+        return;
+    }
 
     if (pyjtypes_ready()) {
         handle_startup_exception(env, "Failed to initialize PyJTypes");
@@ -417,50 +456,6 @@ void pyembed_startup(JNIEnv *env, jobjectArray sharedModulesArgv)
 
     // save a pointer to the main PyThreadState object
     mainThreadState = PyThreadState_Get();
-
-    /*
-     * Workaround for shared modules sys.argv.  Set sys.argv on the main thread.
-     * See github issue #81.
-     */
-    if (sharedModulesArgv != NULL) {
-        wchar_t **argv = NULL;
-        jsize count = 0;
-        int i       = 0;
-
-        count = (*env)->GetArrayLength(env, sharedModulesArgv);
-        (*env)->PushLocalFrame(env, count * 2);
-        argv = (wchar_t**) malloc(count * sizeof(wchar_t*));
-        for (i = 0; i < count; i++) {
-            char* arg     = NULL;
-            wchar_t* argt = NULL;
-            int k = 0;
-            jstring jarg = (*env)->GetObjectArrayElement(env, sharedModulesArgv, i);
-            if (jarg == NULL) {
-                PyEval_ReleaseThread(mainThreadState);
-                (*env)->PopLocalFrame(env, NULL);
-                THROW_JEP(env, "Received null argv.");
-                for (k = 0; k < i; k++) {
-                    free(argv[k]);
-                }
-                free(argv);
-                return;
-            }
-            arg = (char*) (*env)->GetStringUTFChars(env, jarg, NULL);
-            argt = malloc((strlen(arg) + 1) * sizeof(wchar_t));
-            mbstowcs(argt, arg, strlen(arg) + 1);
-            (*env)->ReleaseStringUTFChars(env, jarg, arg);
-            argv[i] = argt;
-        }
-
-        PySys_SetArgvEx(count, argv, 0);
-
-        // free memory
-        for (i = 0; i < count; i++) {
-            free(argv[i]);
-        }
-        free(argv);
-        (*env)->PopLocalFrame(env, NULL);
-    }
 
     PyEval_ReleaseThread(mainThreadState);
 }
@@ -1325,14 +1320,6 @@ void pyembed_run(JNIEnv *env,
                 THROW_JEP(env, "pyembed_run: Can't reopen .pyc file");
                 goto EXIT;
             }
-
-            /* Turn on optimization if a .pyo file is given */
-            if (strcmp(ext, ".pyo") == 0) {
-                Py_OptimizeFlag = 2;
-            } else {
-                Py_OptimizeFlag = 0;
-            }
-
             pyembed_run_pyc(jepThread, script);
         } else {
             PyRun_File(script,

--- a/src/main/java/jep/JepConfig.java
+++ b/src/main/java/jep/JepConfig.java
@@ -33,9 +33,9 @@ import java.util.Set;
 /**
  * <p>
  * A configuration object for constructing a Jep instance, corresponding to the
- * configuration of the particular Python sub-interpreter. This class is
- * intended to make constructing Jep instances easier while maintaining
- * compatible APIs between releases.
+ * configuration of the particular Python interpreter. This class is intended to
+ * make constructing Jep instances easier while maintaining compatible APIs
+ * between releases.
  * </p>
  * 
  * @author Nate Jensen
@@ -58,7 +58,8 @@ public class JepConfig {
 
     protected Set<String> sharedModules = null;
 
-    protected SubInterpreterOptions subInterpOptions = SubInterpreterOptions.legacy();
+    protected SubInterpreterOptions subInterpOptions = SubInterpreterOptions
+            .legacy();
 
     /**
      * Sets a path of directories separated by File.pathSeparator that will be
@@ -195,10 +196,10 @@ public class JepConfig {
     }
 
     /**
-     * Set the configuration options for a sub-interpreter. These options
-     * are only used in Python version 3.12 or later, when using earlier versions
-     * of Python these options are ignored. These options are only used for SubInterpreter
-     * and should not be set when configuring SharedInterpreter.
+     * Set the configuration options for a sub-interpreter. These options are
+     * only used in Python version 3.12 or later, when using earlier versions of
+     * Python these options are ignored. These options are only used for
+     * SubInterpreter and should not be set when configuring SharedInterpreter.
      *
      * @param subInterpOptions
      *            the sub-interpreter options
@@ -206,7 +207,8 @@ public class JepConfig {
      * 
      * @since 4.2
      */
-    public JepConfig setSubInterpreterOptions(SubInterpreterOptions subInterpOptions) {
+    public JepConfig setSubInterpreterOptions(
+            SubInterpreterOptions subInterpOptions) {
         this.subInterpOptions = subInterpOptions;
         return this;
     }

--- a/src/main/java/jep/LibraryLocator.java
+++ b/src/main/java/jep/LibraryLocator.java
@@ -63,12 +63,10 @@ final class LibraryLocator {
     private LibraryLocator(PyConfig pyConfig) {
         String pythonHome;
         if (pyConfig != null) {
-            ignoreEnv = pyConfig.ignoreEnvironmentFlag != 0
-                    && pyConfig.ignoreEnvironmentFlag != -1;
-            noSite = pyConfig.noSiteFlag != 0 && pyConfig.noSiteFlag != -1;
-            noUserSite = pyConfig.noUserSiteDirectory != 0
-                    && pyConfig.noUserSiteDirectory != -1;
-            pythonHome = pyConfig.pythonHome;
+            ignoreEnv = pyConfig.useEnvironment == 0;
+            noSite = pyConfig.siteImport == 0;
+            noUserSite = pyConfig.userSiteDirectory == 0;
+            pythonHome = pyConfig.home;
         } else {
             ignoreEnv = false;
             noSite = false;
@@ -140,8 +138,8 @@ final class LibraryLocator {
                     return true;
                 }
                 for (File pythonDir : libDir.listFiles()) {
-                    if (pythonDir.isDirectory()
-                            && pythonDir.getName().matches("python\\d\\.\\d{1,2}")) {
+                    if (pythonDir.isDirectory() && pythonDir.getName()
+                            .matches("python\\d\\.\\d{1,2}")) {
                         packagesDir = new File(pythonDir, "site-packages");
                         if (searchPackageDir(packagesDir)) {
                             return true;
@@ -186,8 +184,8 @@ final class LibraryLocator {
             File libDir = new File(localDir, "lib");
             if (libDir.isDirectory()) {
                 for (File pythonDir : libDir.listFiles()) {
-                    if (pythonDir.isDirectory()
-                            && pythonDir.getName().matches("python\\d\\.\\d{1,2}")) {
+                    if (pythonDir.isDirectory() && pythonDir.getName()
+                            .matches("python\\d\\.\\d{1,2}")) {
                         File packagesDir = new File(pythonDir, "site-packages");
                         if (searchPackageDir(packagesDir)) {
                             return true;
@@ -197,7 +195,7 @@ final class LibraryLocator {
             }
 
         }
-        
+
         // For Mac framework builds
         if (userHome != null) {
             File localDir = new File(userHome, "Library");
@@ -205,12 +203,14 @@ final class LibraryLocator {
                 File pythonMainDir = new File(localDir, "Python");
                 if (pythonMainDir.isDirectory()) {
                     for (File versionDir : pythonMainDir.listFiles()) {
-                        if (versionDir.isDirectory() && versionDir.getName().matches("\\d\\.\\d{1,2}")) {
+                        if (versionDir.isDirectory() && versionDir.getName()
+                                .matches("\\d\\.\\d{1,2}")) {
                             File libDir = new File(versionDir, "lib");
                             if (libDir.isDirectory()) {
                                 File pythonDir = new File(libDir, "python");
                                 if (pythonDir.isDirectory()) {
-                                    File packagesDir = new File(pythonDir, "site-packages");
+                                    File packagesDir = new File(pythonDir,
+                                            "site-packages");
                                     if (searchPackageDir(packagesDir)) {
                                         return true;
                                     }
@@ -222,7 +222,7 @@ final class LibraryLocator {
                 }
             }
         }
-        
+
         return false;
     }
 
@@ -243,9 +243,11 @@ final class LibraryLocator {
                         System.load(libraryFile.getAbsolutePath());
                     } catch (UnsatisfiedLinkError e) {
                         /*
-                         * This is almost always caused because libpython or pythonXX.dll isn't
-                         * found, so try to figure out the exact libpython that
-                         * is needed and look in PYTHONHOME. Otherwise look in PYTHONHOME for pythonXX.dll
+                         * This is almost always caused because libpython or
+                         * pythonXX.dll isn't found, so try to figure out the
+                         * exact libpython that is needed and look in
+                         * PYTHONHOME. Otherwise look in PYTHONHOME for
+                         * pythonXX.dll
                          * 
                          */
                         Matcher m = Pattern.compile("libpython[\\w\\.]*")

--- a/src/main/java/jep/MainInterpreter.java
+++ b/src/main/java/jep/MainInterpreter.java
@@ -134,11 +134,11 @@ public final class MainInterpreter implements AutoCloseable {
             }
         }
 
-        if (pyConfig != null) {
-            setInitParams(pyConfig.noSiteFlag, pyConfig.noUserSiteDirectory,
-                    pyConfig.ignoreEnvironmentFlag, pyConfig.verboseFlag,
-                    pyConfig.optimizeFlag, pyConfig.dontWriteBytecodeFlag,
-                    pyConfig.hashRandomizationFlag, pyConfig.pythonHome, pyConfig.programName);
+        if (pyConfig == null) {
+            pyConfig = new PyConfig();
+        }
+        if (sharedModulesArgv != null) {
+            pyConfig.setArgv(sharedModulesArgv);
         }
 
         thread = new Thread("JepMainInterpreter") {
@@ -146,7 +146,12 @@ public final class MainInterpreter implements AutoCloseable {
             @Override
             public void run() {
                 try {
-                    initializePython(sharedModulesArgv);
+                    initializePython(pyConfig.argv, pyConfig.hashSeed,
+                            pyConfig.useHashSeed, pyConfig.home,
+                            pyConfig.optimizationLevel, pyConfig.programName,
+                            pyConfig.siteImport, pyConfig.useEnvironment,
+                            pyConfig.userSiteDirectory, pyConfig.verbose,
+                            pyConfig.writeBytecode);
                 } catch (Throwable t) {
                     error = t;
                 } finally {
@@ -239,7 +244,8 @@ public final class MainInterpreter implements AutoCloseable {
      *             if called after the Python interpreter is initialized
      * @since 3.6
      */
-    public static void setInitParams(PyConfig config) throws IllegalStateException {
+    public static void setInitParams(PyConfig config)
+            throws IllegalStateException {
         if (null != instance) {
             throw new IllegalStateException(
                     "Jep.setInitParams(PyConfig) called after initializing python interpreter.");
@@ -258,7 +264,9 @@ public final class MainInterpreter implements AutoCloseable {
      *             if called after the Python interpreter is initialized
      * 
      * @since 3.7
+     * @deprecated Use {@link PyConfig#setArgv(String...)} instead.
      */
+    @Deprecated
     public static void setSharedModulesArgv(String... argv)
             throws IllegalStateException {
         if (instance != null) {
@@ -282,7 +290,8 @@ public final class MainInterpreter implements AutoCloseable {
      * 
      * @since 3.9
      */
-    public static void setJepLibraryPath(String path) throws IllegalStateException {
+    public static void setJepLibraryPath(String path)
+            throws IllegalStateException {
         if (instance != null) {
             throw new IllegalStateException(
                     "Jep.setJepLibraryPath(...) called after initializing python interpreter.");
@@ -290,12 +299,10 @@ public final class MainInterpreter implements AutoCloseable {
         jepLibraryPath = path;
     }
 
-    private static native void setInitParams(int noSiteFlag,
-            int noUserSiteDiretory, int ignoreEnvironmentFlag, int verboseFlag,
-            int optimizeFlag, int dontWriteBytecodeFlag,
-            int hashRandomizationFlag, String pythonHome, String programName);
-
-    private static native void initializePython(String[] mainInterpreterArgv);
+    private static native void initializePython(String[] argv, int hashSeed,
+            int useHashSeed, String home, int optimizationLevel,
+            String programName, int siteImport, int useEnvironment,
+            int userSiteDirectory, int verbose, int writeBytecode);
 
     private static native void sharedImportInternal(String module)
             throws JepException;

--- a/src/main/java/jep/PyConfig.java
+++ b/src/main/java/jep/PyConfig.java
@@ -126,7 +126,7 @@ public class PyConfig {
      * standard Python libraries.
      * 
      * @param home
-     *            the directory tpuse for Python home.
+     *            the directory to use for Python home.
      * @return a reference to this PyConfig
      * @see https://docs.python.org/3/c-api/init_config.html#c.PyConfig.home
      */
@@ -256,8 +256,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setNoSiteFlag(int noSiteFlag) {
-        this.siteImport = (noSiteFlag == 0) ? 1 : 0;
-        return this;
+        return setSiteImport(noSiteFlag == 0);
     }
 
     /**
@@ -272,8 +271,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setNoUserSiteDirectory(int noUserSiteDirectory) {
-        this.userSiteDirectory = (noUserSiteDirectory == 0) ? 1 : 0;
-        return this;
+        return this.setUserSiteDirectory(noUserSiteDirectory == 0);
     }
 
     /**
@@ -288,8 +286,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setIgnoreEnvironmentFlag(int ignoreEnvironmentFlag) {
-        this.useEnvironment = (ignoreEnvironmentFlag == 0) ? 1 : 0;
-        return this;
+        return this.setUseEnvironment(ignoreEnvironmentFlag == 0);
     }
 
     /**
@@ -304,8 +301,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setVerboseFlag(int verboseFlag) {
-        this.verbose = verboseFlag;
-        return this;
+        return this.setVerbose(verboseFlag);
     }
 
     /**
@@ -320,8 +316,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setOptimizeFlag(int optimizeFlag) {
-        this.optimizationLevel = optimizeFlag;
-        return this;
+        return this.setOptimizationLevel(optimizeFlag);
     }
 
     /**
@@ -336,8 +331,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setDontWriteBytecodeFlag(int dontWriteBytecodeFlag) {
-        this.writeBytecode = (dontWriteBytecodeFlag == 0) ? 1 : 0;
-        return this;
+        return this.setWriteBytecode(dontWriteBytecodeFlag == 0);
     }
 
     /**
@@ -352,11 +346,11 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setHashRandomizationFlag(int hashRandomizationFlag) {
-        if (hashRandomizationFlag == 0) {
-            this.useHashSeed = 0;
+        if (hashRandomizationFlag == 1) {
+            this.setUseHashSeed(false);
         } else {
-            this.hashSeed = hashRandomizationFlag;
-            this.useHashSeed = 1;
+            this.setHashSeed(hashRandomizationFlag);
+            this.setUseHashSeed(true);
         }
         return this;
     }
@@ -373,8 +367,7 @@ public class PyConfig {
      */
     @Deprecated
     public PyConfig setPythonHome(String pythonHome) {
-        this.home = pythonHome;
-        return this;
+        return this.setHome(pythonHome);
     }
 
     @Override

--- a/src/test/java/jep/test/TestPreInitVariables.java
+++ b/src/test/java/jep/test/TestPreInitVariables.java
@@ -30,12 +30,12 @@ public class TestPreInitVariables {
         // pyConfig.setIgnoreEnvironmentFlag(1);
         // TODO fix test so no site flag can be tested
         // pyConfig.setNoSiteFlag(1);
-        pyConfig.setNoUserSiteDirectory(1);
+        pyConfig.setUserSiteDirectory(false);
         // verbose prints out too much, when it's on, it's clear it's on
         // pyConfig.setVerboseFlag(1);
-        pyConfig.setOptimizeFlag(1);
-        pyConfig.setDontWriteBytecodeFlag(1);
-        pyConfig.setHashRandomizationFlag(1);
+        pyConfig.setOptimizationLevel(1);
+        pyConfig.setWriteBytecode(false);
+        pyConfig.setUseHashSeed(false);
         MainInterpreter.setInitParams(pyConfig);
         try (Interpreter interp = new SubInterpreter(
                 new JepConfig().addIncludePaths("."))) {
@@ -43,16 +43,18 @@ public class TestPreInitVariables {
             // assert 1 == ((Number)
             // jep.getValue("sys.flags.ignore_environment"))
             // .intValue();
-            assert 0 == ((Number) interp.getValue("sys.flags.no_site")).intValue();
+            assert 0 == ((Number) interp.getValue("sys.flags.no_site"))
+                    .intValue();
             assert 1 == ((Number) interp.getValue("sys.flags.no_user_site"))
                     .intValue();
-            assert 0 == ((Number) interp.getValue("sys.flags.verbose")).intValue();
+            assert 0 == ((Number) interp.getValue("sys.flags.verbose"))
+                    .intValue();
             assert 1 == ((Number) interp.getValue("sys.flags.optimize"))
                     .intValue();
-            assert 1 == ((Number) interp.getValue("sys.flags.dont_write_bytecode"))
-                    .intValue();
-            assert 1 == ((Number) interp.getValue("sys.flags.hash_randomization"))
-                    .intValue();
+            assert 1 == ((Number) interp
+                    .getValue("sys.flags.dont_write_bytecode")).intValue();
+            assert 1 == ((Number) interp
+                    .getValue("sys.flags.hash_randomization")).intValue();
         } catch (Throwable e) {
             e.printStackTrace();
             System.exit(1);

--- a/src/test/java/jep/test/TestPreInitVariables.java
+++ b/src/test/java/jep/test/TestPreInitVariables.java
@@ -1,11 +1,10 @@
 package jep.test;
 
 import jep.Interpreter;
-import jep.JepConfig;
 import jep.JepException;
 import jep.MainInterpreter;
 import jep.PyConfig;
-import jep.SubInterpreter;
+import jep.SharedInterpreter;
 
 /**
  * A test class for verifying that Jep can correctly configure the global Python
@@ -37,8 +36,7 @@ public class TestPreInitVariables {
         pyConfig.setWriteBytecode(false);
         pyConfig.setUseHashSeed(false);
         MainInterpreter.setInitParams(pyConfig);
-        try (Interpreter interp = new SubInterpreter(
-                new JepConfig().addIncludePaths("."))) {
+        try (Interpreter interp = new SharedInterpreter()) {
             interp.eval("import sys");
             // assert 1 == ((Number)
             // jep.getValue("sys.flags.ignore_environment"))

--- a/src/test/java/jep/test/TestSharedArgv.java
+++ b/src/test/java/jep/test/TestSharedArgv.java
@@ -38,6 +38,9 @@ public class TestSharedArgv {
             interp.eval("import logging");
             List<String> result = (List<String>) interp
                     .getValue("logging.sys.argv");
+            if (argv.length != result.size()) {
+                throw new RuntimeException("len(argv) did not match");
+            }
             for (int i = 0; i < result.size(); i++) {
                 if (!result.get(i).equals(argv[i])) {
                     throw new RuntimeException("argv[" + i + "] did not match");

--- a/src/test/java/jep/test/TestSharedArgv.java
+++ b/src/test/java/jep/test/TestSharedArgv.java
@@ -6,6 +6,7 @@ import jep.Interpreter;
 import jep.JepConfig;
 import jep.JepException;
 import jep.MainInterpreter;
+import jep.PyConfig;
 import jep.SubInterpreter;
 
 /**
@@ -23,8 +24,7 @@ public class TestSharedArgv {
     public static void main(String[] args) throws JepException {
 
         final String[] argv = new String[] { "", "-h", "other" };
-
-        MainInterpreter.setSharedModulesArgv(argv);
+        MainInterpreter.setInitParams(new PyConfig().setArgv(argv));
         JepConfig cfg = new JepConfig();
         cfg.addSharedModules("logging");
         cfg.addIncludePaths(".");

--- a/src/test/python/test_preinits.py
+++ b/src/test/python/test_preinits.py
@@ -12,10 +12,11 @@ def containsBug46006():
     # upcoming releases such as 3.10.2 and 3.11.
     if sys.version_info.major == 3 and sys.version_info.minor == 10: 
         return sys.version_info.micro == 0 or sys.version_info.micro == 1
+    return False
 
 class TestPreInits(unittest.TestCase):
 
-    @unittest.skipIf(containsBug46006, 'Python version contains cpython bug 46006 and may not work with DontWriteBytecodeFlag')
+    @unittest.skipIf(containsBug46006(), 'Python version contains cpython bug 46006 and may not work with DontWriteBytecodeFlag')
     def test_inits(self):
         jep_pipe(build_java_process_cmd('jep.test.TestPreInitVariables'))
 


### PR DESCRIPTION
The PyConfig Java class is currently used to set Python [Global Configuration Variables](https://docs.python.org/3/c-api/init.html#global-configuration-variables) but this part of the Python c-api has been deprecated since Python 3.12 and is scheduled for removal in 3.14. [PEP-587](https://peps.python.org/pep-0587/) describes a new mechanism for handling [Python Initialization Configuration](https://docs.python.org/3/c-api/init_config.html#python-initialization-configuration). This change removes the use of the deprecated variables and switches things over to the new way of doing things. This change should be fully backwards compatible for anyone using Jep, however many public methods in PyConfig are now deprecated.

Now that the Python c-api includes a PyConfig structure I changed our PyConfig class in Java to have fields and setters corresponding to the c-api structure. Making these match up keeps the native code simple and I think this will be easier to document and maintain moving forward but it makes this change confusing because [several of the fields were inverted](https://peps.python.org/pep-0587/#global-configuration-variables) in the transition. As an example there was previously a configuration variable called DontWriteBytecode and it has been replaced with a field called WriteBytecode so if previously DontWriteByteCode was true instead now WriteByteCode should be false. In the java PyConfig class this means the existing `setDontWriteBytecodeFlag()` method is deprecated and a new `setWriteBytecode()` has been added. 

