### PR TITLE
Move build metadata from setup.py to pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 name = "jep"
 description = "Jep embeds CPython in Java through JNI."
 dynamic = ["version"]
-license = { "text" = "zlib/libpng"}
+license = { "text" = "Zlib"}
 readme = "README.rst"
 requires-python = ">= 3.10"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta:__legacy__"
 name = "jep"
 description = "Jep embeds CPython in Java through JNI."
 dynamic = ["version"]
-#version = "4.3.0"
 license = { "text" = "zlib/libpng"}
 readme = "README.rst"
 requires-python = ">= 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta:__legacy__"
+
+[project]
+name = "jep"
+description = "Jep embeds CPython in Java through JNI."
+dynamic = ["version"]
+#version = "4.3.0"
+license = { "text" = "zlib/libpng"}
+readme = "README.rst"
+requires-python = ">= 3.10"
+authors = [
+  {name = "Mike Johnson", email = "mike@mrj0.com"}
+]
+maintainers = [
+  {name = "Nate Jensen", email = "ndjensen@gmail.com"},
+  {name = "Ben Steffensmeier", email = "ben.steffensmeier@gmail.com"}
+]
+classifiers = [
+  "License :: OSI Approved :: zlib/libpng License",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development",
+  "Topic :: Software Development :: Libraries :: Java Libraries",
+  "Programming Language :: Java",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: Implementation :: CPython"
+]
+keywords = ["java"]
+
+[project.urls]
+Homepage = "https://github.com/ninia/jep"
+Documentation = "https://github.com/ninia/jep/wiki"
+JavaDoc = "https://ninia.github.io/jep/javadoc"
+Repository = "https://github.com/ninia/jep.git"
+Issues = "https://github.com/ninia/jep.issues"
+
+[project.optional-dependencies]
+numpy = ["numpy >= 1.7"]

--- a/setup.py
+++ b/setup.py
@@ -81,31 +81,10 @@ if __name__ == '__main__':
         #Disable warnings about Secure CRT Functions in util.c and pyembed.c.
         defines.append(('_CRT_SECURE_NO_WARNINGS', 1))
 
-    setup(name='jep',
-          version=VERSION,
-          description='Jep embeds CPython in Java',
-          long_description=read_file('README.rst'),
-          author='Jep Developers',
-          author_email='jep-project@googlegroups.com',
-          url='https://github.com/ninia/jep',
+    setup(version=VERSION,
           packages=['jep'],
           package_dir={'': 'src/main/python'},
           scripts=['src/main/scripts/jep'],
-          keywords='java',
-          license='zlib/libpng',
-          classifiers=[
-                       'License :: OSI Approved :: zlib/libpng License',
-                       'Development Status :: 5 - Production/Stable',
-                       'Intended Audience :: Developers',
-                       'Topic :: Software Development',
-                       'Programming Language :: Java',
-                       'Programming Language :: Python',
-                       'Programming Language :: Python :: 3.10',
-                       'Programming Language :: Python :: 3.11',
-                       'Programming Language :: Python :: 3.12',
-                       'Programming Language :: Python :: 3.13',
-                       'Programming Language :: Python :: Implementation :: CPython',
-                      ],
           ext_modules=[
               Extension(
                   name='jep',


### PR DESCRIPTION
This moves the build metadata into pyproject.toml. As far as I can tell there is no immediate benefit to this change but it aligns with current best practices for building a python project and I suspect it is inevitable we will need to use pyproject.toml at some point in the future so I would like to have a starting version to work with in the future.

With this change I am still able to build using either `pip install --no-build-isolation .` or `setup.py install`. I still get a deprecation warning when running setup.py directly.