### PR TITLE
Make all jep types compatible with isolated interpreters.

### DIFF
--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -42,6 +42,12 @@ struct __JepThread {
 };
 typedef struct __JepThread JepThread;
 
+struct __JepModuleState {
+    PyTypeObject *PyJObject_Type;
+    PyTypeObject *PyJClass_Type;
+    PyTypeObject *PyJArray_Type;
+};
+typedef struct __JepModuleState JepModuleState;
 
 void pyembed_startup(JNIEnv*, jobjectArray, jint, jint, jstring, jint, jstring,
                      jint, jint, jint, jint, jint);
@@ -68,6 +74,8 @@ jobject pyembed_getvalue(JNIEnv*, intptr_t, char*, jclass);
 JNIEnv* pyembed_get_env(void);
 JepThread* pyembed_get_jepthread(void);
 PyObject* pyembed_get_jep_module(void);
+JepModuleState* pyembed_get_module_state(void);
+
 
 // -------------------------------------------------- set() methods
 

--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -75,7 +75,6 @@ JNIEnv* pyembed_get_env(void);
 JepThread* pyembed_get_jepthread(void);
 PyObject* pyembed_get_jep_module(void);
 JepModuleState* pyembed_get_module_state(void);
-
 
 // -------------------------------------------------- set() methods
 

--- a/src/main/c/Include/pyjarray.h
+++ b/src/main/c/Include/pyjarray.h
@@ -32,7 +32,7 @@
 #define _Included_pyjarray
 
 
-extern PyTypeObject PyJArray_Type;
+extern PyType_Spec PyJArray_Spec;
 
 // c storage for our stuff, managed by python interpreter.
 typedef struct {

--- a/src/main/c/Include/pyjarray.h
+++ b/src/main/c/Include/pyjarray.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Include/pyjclass.h
+++ b/src/main/c/Include/pyjclass.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Include/pyjclass.h
+++ b/src/main/c/Include/pyjclass.h
@@ -36,7 +36,7 @@
 #ifndef _Included_pyjclass
 #define _Included_pyjclass
 
-extern PyTypeObject PyJClass_Type;
+extern PyType_Spec PyJClass_Spec;
 
 typedef struct {
     PyObject_HEAD
@@ -52,8 +52,6 @@ typedef struct {
 
 PyObject* PyJClass_Wrap(JNIEnv*, jobject);
 
-#define PyJClass_Check(pyobj) \
-    PyObject_TypeCheck(pyobj, &PyJClass_Type)
-
+int PyJClass_Check(PyObject*);
 
 #endif // ndef pyjclass

--- a/src/main/c/Include/pyjobject.h
+++ b/src/main/c/Include/pyjobject.h
@@ -31,7 +31,7 @@
 #define _Included_pyjobject
 
 
-extern PyTypeObject PyJObject_Type;
+extern PyType_Spec PyJObject_Spec;
 
 /*
  * The common fields for PyJObject. The usage of this macro is similar to
@@ -59,8 +59,7 @@ typedef struct {
  */
 PyObject* PyJObject_New(JNIEnv*, PyTypeObject*, jobject, jclass);
 
-#define PyJObject_Check(pyobj) \
-    PyObject_TypeCheck(pyobj, &PyJObject_Type)
+int PyJObject_Check(PyObject*);
 
 
 #endif // ndef pyjobject

--- a/src/main/c/Include/pyjobject.h
+++ b/src/main/c/Include/pyjobject.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -157,17 +157,54 @@ static struct PyMethodDef jep_methods[] = {
 
     { NULL, NULL }
 };
+
+static void free_jep_module(PyObject* modjep)
+{
+    JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
+    if (modState) {
+        Py_CLEAR(modState->PyJObject_Type);
+        Py_CLEAR(modState->PyJClass_Type);
+        Py_CLEAR(modState->PyJArray_Type);
+    }
+}
+
 static struct PyModuleDef jep_module_def = {
     PyModuleDef_HEAD_INIT,
-    "_jep",              /* m_name */
-    "_jep",              /* m_doc */
-    0,                   /* m_size */
-    jep_methods,         /* m_methods */
-    NULL,                /* m_reload */
-    NULL,                /* m_traverse */
-    NULL,                /* m_clear */
-    NULL,                /* m_free */
+    "_jep",                     /* m_name */
+    "_jep",                     /* m_doc */
+    sizeof(JepModuleState),     /* m_size */
+    jep_methods,                /* m_methods */
+    NULL,                       /* m_reload */
+    NULL,                       /* m_traverse */
+    NULL,                       /* m_clear */
+    (freefunc) free_jep_module, /* m_free */
 };
+
+static int pyjtypes_ready(PyObject *modjep)
+{
+    JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
+    if (!modState) {
+        return -1;
+    }
+    modState->PyJObject_Type = (PyTypeObject*) PyType_FromSpec(&PyJObject_Spec);
+    if (!modState->PyJObject_Type) {
+        return -1;
+    }
+    modState->PyJClass_Type = (PyTypeObject*) PyType_FromSpecWithBases(
+                                  &PyJClass_Spec, (PyObject*) modState->PyJObject_Type);
+    if (!modState->PyJClass_Type) {
+        Py_CLEAR(modState->PyJObject_Type);
+        return -1;
+    }
+    modState->PyJArray_Type = (PyTypeObject*) PyType_FromSpecWithBases(
+                                  &PyJArray_Spec, (PyObject*) modState->PyJObject_Type);
+    if (!modState->PyJArray_Type) {
+        Py_CLEAR(modState->PyJObject_Type);
+        Py_CLEAR(modState->PyJClass_Type);
+        return -1;
+    }
+    return 0;
+}
 
 /*
  * Initialize the _jep module.
@@ -220,6 +257,12 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             Py_INCREF(mainThreadModulesLock);
             PyModule_AddObject(modjep, "mainInterpreterModulesLock", mainThreadModulesLock);
         }
+        if (pyjtypes_ready(modjep)) {
+            Py_DECREF(modjep);
+            handle_startup_exception(env, "Failed to initialize PyJTypes");
+            return -1;
+        }
+
         /* still held by sys.modules. */
         Py_DECREF(modjep);
 #if JEP_NUMPY_ENABLED
@@ -227,29 +270,6 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             return -1;
         }
 #endif
-    }
-    return 0;
-}
-
-/*
- * MSVC requires tp_base to be set at runtime instead of in the type
- * declaration. :/  Otherwise we could just set tp_base in the type declaration
- * and be done with it.  Since we are building an inheritance tree of types, we
- * need to ensure that all the tp_base are set for the subtypes before we
- * possibly use those subtypes.
- *
- * See https://docs.python.org/3/extending/newtypes.html
- */
-static int pyjtypes_ready(void)
-{
-    if (PyType_Ready(&PyJObject_Type) < 0) {
-        return -1;
-    }
-    if (!PyJClass_Type.tp_base) {
-        PyJClass_Type.tp_base = &PyJObject_Type;
-    }
-    if (PyType_Ready(&PyJClass_Type) < 0) {
-        return -1;
     }
     return 0;
 }
@@ -411,11 +431,6 @@ void pyembed_startup(JNIEnv *env,
             (*env)->ThrowNew(env, excClass, status.err_msg);
         }
         // The exit code is ignored, because exiting seems rude.
-        return;
-    }
-
-    if (pyjtypes_ready()) {
-        handle_startup_exception(env, "Failed to initialize PyJTypes");
         return;
     }
 
@@ -768,6 +783,17 @@ PyObject* pyembed_get_jep_module(void)
         PyErr_SetString(PyExc_ModuleNotFoundError, "Module _jep was not found.");
     }
     return modjep;
+}
+
+JepModuleState* pyembed_get_module_state(void)
+{
+    PyObject* modjep = pyembed_get_jep_module();
+    if (modjep) {
+        return (JepModuleState*) PyModule_GetState(modjep);
+    } else {
+        return NULL;
+    }
+
 }
 
 static PyObject* pyembed_jproxy(PyObject *self, PyObject *args)

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -793,7 +793,6 @@ JepModuleState* pyembed_get_module_state(void)
     } else {
         return NULL;
     }
-
 }
 
 static PyObject* pyembed_jproxy(PyObject *self, PyObject *args)
@@ -1468,7 +1467,6 @@ static int maybe_pyc_file(FILE *fp, const char* filename, const char* ext,
     pymodule = NULL;                                                \
     if(module != 0)                                                 \
         pymodule = (PyObject *) module;
-
 
 
 void pyembed_setparameter_object(JNIEnv *env,

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -37,24 +37,21 @@ static int pyjarray_init(JNIEnv*, PyJArrayObject*, int, PyObject*);
 static Py_ssize_t pyjarray_length(PyObject *self);
 
 
-
 // called internally to make new PyJArrayObject instances
 PyObject* pyjarray_new(JNIEnv *env, jobjectArray obj)
 {
     PyJArrayObject  *pyarray;
-
-    if (!PyJArray_Type.tp_base) {
-        PyJArray_Type.tp_base = &PyJObject_Type;
-    }
-    if (PyType_Ready(&PyJArray_Type) < 0) {
-        return NULL;
-    }
     if (!obj) {
         PyErr_Format(PyExc_RuntimeError, "Invalid array object.");
         return NULL;
     }
 
-    pyarray = (PyJArrayObject*) PyJObject_New(env, &PyJArray_Type, obj, NULL);
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return NULL;
+    }
+    pyarray = (PyJArrayObject*) PyJObject_New(env, modState->PyJArray_Type, obj,
+              NULL);
     if (!pyarray) {
         return NULL;
     }
@@ -88,13 +85,6 @@ PyObject* pyjarray_new_v(PyObject *isnull, PyObject *args)
     // args
     PyObject *one, *two, *three;
     one = two = three = NULL;
-
-    if (!PyJArray_Type.tp_base) {
-        PyJArray_Type.tp_base = &PyJObject_Type;
-    }
-    if (PyType_Ready(&PyJArray_Type) < 0) {
-        return NULL;
-    }
 
     env = pyembed_get_env();
 
@@ -262,7 +252,12 @@ PyObject* pyjarray_new_v(PyObject *isnull, PyObject *args)
         return NULL;
     }
 
-    pyarray = (PyJArrayObject*) PyJObject_New(env, &PyJArray_Type, arrayObj, NULL);
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return NULL;
+    }
+    pyarray = (PyJArrayObject*) PyJObject_New(env, modState->PyJArray_Type,
+              arrayObj, NULL);
     if (!pyarray) {
         return NULL;
     }
@@ -568,7 +563,7 @@ static void pyjarray_dealloc(PyJArrayObject *self)
         // can't guarantee mode 0 will work in this case...
         pyjarray_release_pinned(self, JNI_ABORT);
     }
-    PyJArray_Type.tp_base->tp_dealloc((PyObject*) self);
+    Py_TYPE(self)->tp_base->tp_dealloc((PyObject*) self);
 #endif
 }
 
@@ -648,11 +643,13 @@ void pyjarray_release_pinned(PyJArrayObject *self, jint mode)
     } // switch
 }
 
-
 int pyjarray_check(PyObject *obj)
 {
-    if (PyObject_TypeCheck(obj, &PyJArray_Type)) {
-        return 1;
+    JepModuleState* modState = pyembed_get_module_state();
+    if (modState) {
+        if (PyObject_TypeCheck(obj, modState->PyJArray_Type)) {
+            return 1;
+        }
     }
     return 0;
 }
@@ -866,8 +863,8 @@ static PyObject* pyjarray_item(PyJArrayObject *self, Py_ssize_t pos)
         jstring     jstr;
 
         jstr = (jstring) (*env)->GetObjectArrayElement(env,
-                self->object,
-                (jsize) pos);
+               self->object,
+               (jsize) pos);
 
         if (process_java_exception(env))
             ;
@@ -888,8 +885,8 @@ static PyObject* pyjarray_item(PyJArrayObject *self, Py_ssize_t pos)
         jobjectArray obj;
 
         obj = (jobjectArray) (*env)->GetObjectArrayElement(env,
-                self->object,
-                (jsize) pos);
+              self->object,
+              (jsize) pos);
 
         if (process_java_exception(env))
             ;
@@ -1561,7 +1558,8 @@ static PyObject* pyjarray_subscript(PyJArrayObject *self, PyObject *item)
         return pyjarray_item(self, (Py_ssize_t) i);
     } else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength;
-        if (PySlice_GetIndicesEx(item, pyjarray_length((PyObject*) self), &start, &stop,
+        if (PySlice_GetIndicesEx(item, pyjarray_length((PyObject * ) self), &start,
+                                 &stop,
                                  &step, &slicelength) < 0) {
             // error will already be set
             return NULL;
@@ -1626,69 +1624,29 @@ PyMethodDef pyjarray_methods[] = {
     { NULL, NULL }
 };
 
-
-static PySequenceMethods list_as_sequence = {
-    (lenfunc) pyjarray_length,                /* sq_length */
-    (binaryfunc) 0,                           /* sq_concat */
-    (ssizeargfunc) 0,                         /* sq_repeat */
-    (ssizeargfunc) pyjarray_item,             /* sq_item */
-    (ssizessizeargfunc) pyjarray_slice,       /* sq_slice */
-    (ssizeobjargproc) pyjarray_setitem,       /* sq_ass_item */
-    (ssizessizeobjargproc) 0,                 /* sq_ass_slice */
-    (objobjproc) pyjarray_contains,           /* sq_contains */
-    (binaryfunc) 0,                           /* sq_inplace_concat */
-    (ssizeargfunc) 0,                         /* sq_inplace_repeat */
-};
-
-static PyMappingMethods pyjarray_map_methods = {
-    (lenfunc) pyjarray_length,                /* mp_length */
-    (binaryfunc) pyjarray_subscript,          /* mp_subscript */
-    0,                                        /* mp_ass_subscript */
-};
-
-
 static PyObject* pyjarray_iter(PyObject *);
 
+static PyType_Slot slots[] = {
+    {Py_tp_doc, (void*) &list_doc},
+    // sequence slots
+    {Py_sq_length, pyjarray_length},
+    {Py_sq_item, pyjarray_item},
+    {Py_sq_ass_item, pyjarray_setitem},
+    {Py_sq_contains, pyjarray_contains},
+    // mapping methods
+    {Py_mp_subscript, pyjarray_subscript},
+    {Py_tp_dealloc, pyjarray_dealloc},
+    {Py_tp_str, pyjarray_str},
+    {Py_tp_iter, pyjarray_iter},
+    {Py_tp_methods, pyjarray_methods},
+    {0, NULL},
+};
 
-PyTypeObject PyJArray_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJArray",                           /* tp_name */
-    sizeof(PyJArrayObject),                   /* tp_basicsize */
-    0,                                        /* tp_itemsize */
-    (destructor) pyjarray_dealloc,            /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    &list_as_sequence,                        /* tp_as_sequence */
-    &pyjarray_map_methods,                    /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    0,                                        /* tp_call */
-    (reprfunc) pyjarray_str,                  /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
-    list_doc,                                 /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    pyjarray_iter,                            /* tp_iter */
-    0,                                        /* tp_iternext */
-    pyjarray_methods,                         /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+PyType_Spec PyJArray_Spec = {
+    .name = "jep.PyJArray",
+    .basicsize = sizeof(PyJArrayObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = slots
 };
 
 
@@ -1799,7 +1757,8 @@ PyTypeObject PyJArrayIter_Type = {
     (getattrofunc) pyjarrayiter_dealloc,      /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     0,                                        /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -643,6 +643,7 @@ void pyjarray_release_pinned(PyJArrayObject *self, jint mode)
     } // switch
 }
 
+
 int pyjarray_check(PyObject *obj)
 {
     JepModuleState* modState = pyembed_get_module_state();
@@ -862,9 +863,7 @@ static PyObject* pyjarray_item(PyJArrayObject *self, Py_ssize_t pos)
     case JSTRING_ID: {
         jstring     jstr;
 
-        jstr = (jstring) (*env)->GetObjectArrayElement(env,
-               self->object,
-               (jsize) pos);
+        jstr = (jstring) (*env)->GetObjectArrayElement(env, self->object, (jsize) pos);
 
         if (process_java_exception(env))
             ;
@@ -884,9 +883,8 @@ static PyObject* pyjarray_item(PyJArrayObject *self, Py_ssize_t pos)
     case JARRAY_ID: {
         jobjectArray obj;
 
-        obj = (jobjectArray) (*env)->GetObjectArrayElement(env,
-              self->object,
-              (jsize) pos);
+        obj = (jobjectArray) (*env)->GetObjectArrayElement(env, self->object,
+                (jsize) pos);
 
         if (process_java_exception(env))
             ;
@@ -1559,8 +1557,7 @@ static PyObject* pyjarray_subscript(PyJArrayObject *self, PyObject *item)
     } else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength;
         if (PySlice_GetIndicesEx(item, pyjarray_length((PyObject * ) self), &start,
-                                 &stop,
-                                 &step, &slicelength) < 0) {
+                                 &stop, &step, &slicelength) < 0) {
             // error will already be set
             return NULL;
         }

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -486,7 +486,7 @@ static PyType_Slot slots[] = {
 };
 
 PyType_Spec PyJClass_Spec = {
-    .name = "java.lang.Class",
+    .name = "jep.PyJClass",
     .basicsize = sizeof(PyJClassObject),
     .flags = Py_TPFLAGS_DEFAULT,
     .slots = slots

--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -340,7 +340,8 @@ PyTypeObject PyJConstructor_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     "jconstructor",                           /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2016-2022 JEP AUTHORS.
+   Copyright (c) 2016-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -667,7 +667,8 @@ PyTypeObject PyJField_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     "jfield",                                 /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -895,7 +895,8 @@ PyTypeObject PyJMethod_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     "jmethod",                                /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2017-2022 JEP AUTHORS.
+   Copyright (c) 2017-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -161,7 +161,8 @@ PyTypeObject PyJMonitor_Type = {
     PyObject_GenericGetAttr,                  /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     "jmonitor",                               /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -239,7 +239,8 @@ PyTypeObject PyJMultiMethod_Type = {
     0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                       /* tp_flags */
+    Py_TPFLAGS_DEFAULT |
+     Py_TPFLAGS_IMMUTABLETYPE,                /* tp_flags */
     pyjmultimethod_doc,                       /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2015-2022 JEP AUTHORS.
+   Copyright (c) 2015-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -240,7 +240,7 @@ PyTypeObject PyJMultiMethod_Type = {
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT |
-     Py_TPFLAGS_IMMUTABLETYPE,                /* tp_flags */
+    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
     pyjmultimethod_doc,                       /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -41,7 +41,6 @@ int PyJObject_Check(PyObject *pyobj)
     }
     return 0;
 }
-
 
 PyObject* PyJObject_New(JNIEnv *env, PyTypeObject* type, jobject obj,
                         jclass class)

--- a/src/main/c/Objects/pyjtype.c
+++ b/src/main/c/Objects/pyjtype.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2020-2022 JEP AUTHORS.
+   Copyright (c) 2020-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -32,7 +32,6 @@ static PyTypeObject PyJType_Type;
 static PyTypeObject* pyjtype_get_cached(JNIEnv*, PyObject*, jclass);
 static int addMethods(JNIEnv*, PyObject*, jclass);
 
-
 /*
  * Populate pyjmethods for a type and add it to the cache. This is for custom
  * types with extra logic in c since we are not able to add pyjmethods before
@@ -43,7 +42,7 @@ static int addMethods(JNIEnv*, PyObject*, jclass);
 static PyTypeObject* addCustomTypeToTypeDict(JNIEnv *env, PyObject* fqnToPyType,
         jclass class, PyTypeObject *type)
 {
-    if (PyDict_SetItemString(fqnToPyType, type->tp_name, (PyObject * ) type)) {
+    if (PyDict_SetItemString(fqnToPyType, type->tp_name, (PyObject*) type)) {
         return NULL;
     }
     /*
@@ -229,7 +228,6 @@ static PyObject* getBaseTypes(JNIEnv *env, PyObject *fqnToPyType, jclass clazz)
 }
 
 
-
 /*
  * Adding empty slots to the type dict to prevent creation of __dict__ for
  * every instance and ensures all attribute access goes through the original
@@ -317,7 +315,7 @@ static int addMethods(JNIEnv* env, PyObject* dict, jclass clazz)
         PyObject* cached = PyDict_GetItem(dict, pymethod->pyMethodName);
         if (cached == NULL) {
             if (PyDict_SetItem(dict, pymethod->pyMethodName,
-                               (PyObject * ) pymethod) != 0) {
+                               (PyObject*) pymethod) != 0) {
                 Py_DECREF(pymethod);
                 return -1;
             }
@@ -372,7 +370,7 @@ static int addFields(JNIEnv* env, PyObject* dict, jclass clazz)
                 return -1;
             }
 
-            if (PyDict_SetItem(dict, pyjfield->pyFieldName, (PyObject * ) pyjfield) != 0) {
+            if (PyDict_SetItem(dict, pyjfield->pyFieldName, (PyObject*) pyjfield) != 0) {
                 return -1;
             }
 
@@ -439,7 +437,7 @@ static PyTypeObject* pyjtype_get_new(JNIEnv *env, PyObject *fqnToPyType,
          * See https://docs.python.org/3/library/functions.html#type
          */
         type = (PyTypeObject*) PyObject_CallFunctionObjArgs((PyObject*) &PyJType_Type,
-               shortName, bases, dict, NULL);
+                shortName, bases, dict, NULL);
     }
     Py_DECREF(bases);
     Py_DECREF(dict);
@@ -562,7 +560,7 @@ static PyObject* pyjtype_mro(PyObject* self, PyObject* unused)
                 return NULL;
             }
         }
-        if (merge_mro(((PyTypeObject * ) base), mro_list)) {
+        if (merge_mro(((PyTypeObject*) base), mro_list)) {
             Py_DECREF(mro_list);
             return NULL;
         }
@@ -627,4 +625,3 @@ static PyTypeObject PyJType_Type = {
     0,                                        /* tp_alloc */
     NULL,                                     /* tp_new */
 };
-


### PR DESCRIPTION
This change makes it so that all the jep types declared in c code are compatible with sub interpreters. PyJObject and its subclasses(pyjclass and pyjarray) are converted to heap types and each interpreter now has a separate instance of those types that is stored in the module state for the _jep module. All other static types created by jep are now flagged as immutable which allows them to be shared between isolated interpreters.

In my tests this change resolves the crash seen in #593.