### PR TITLE
Expose PyConfig options for isolation and arg parsing.

### DIFF
--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -49,8 +49,8 @@ struct __JepModuleState {
 };
 typedef struct __JepModuleState JepModuleState;
 
-void pyembed_startup(JNIEnv*, jobjectArray, jint, jint, jstring, jint, jstring,
-                     jint, jint, jint, jint, jint);
+void pyembed_startup(JNIEnv*, jboolean, jobjectArray, jint, jint, jstring, jint,
+                     jint, jstring, jint, jint, jint, jint, jint);
 void pyembed_shutdown(JavaVM*);
 void pyembed_shared_import(JNIEnv*, jstring);
 

--- a/src/main/c/Jep/maininterpreter.c
+++ b/src/main/c/Jep/maininterpreter.c
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2016-2022 JEP AUTHORS.
+   Copyright (c) 2016-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -35,16 +35,18 @@
 /*
  * Class:     jep_MainInterpreter
  * Method:    initializePython
- * Signature: ([Ljava/lang/String;IILjava/lang/String;ILjava/lang/String;IIIII)V
+ * Signature: (Z[Ljava/lang/String;IILjava/lang/String;IILjava/lang/String;IIIII)V
  */
 JNIEXPORT void JNICALL Java_jep_MainInterpreter_initializePython
 (JNIEnv *env,
  jclass class,
+ jboolean isolated,
  jobjectArray argv,
  jint hashSeed,
  jint useHashSeed,
  jstring home,
  jint optimizationLevel,
+ jint parseArgv,
  jstring programName,
  jint siteImport,
  jint useEnvironment,
@@ -53,9 +55,9 @@ JNIEXPORT void JNICALL Java_jep_MainInterpreter_initializePython
  jint writeByteCode
 )
 {
-    pyembed_startup(env, argv, hashSeed, useHashSeed, home, optimizationLevel,
-                    programName, siteImport, useEnvironment, userSiteDirectory, verbose,
-                    writeByteCode);
+    pyembed_startup(env, isolated, argv, hashSeed, useHashSeed, home,
+                    optimizationLevel, parseArgv, programName, siteImport, useEnvironment,
+                    userSiteDirectory, verbose, writeByteCode);
 }
 
 /*

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -287,11 +287,13 @@ static void handle_startup_exception(JNIEnv *env, const char* excMsg)
 
 
 void pyembed_startup(JNIEnv *env,
+                     jboolean isolated,
                      jobjectArray argv,
                      jint hashSeed,
                      jint useHashSeed,
                      jstring home,
                      jint optimizationLevel,
+                     jint parseArgv,
                      jstring programName,
                      jint siteImport,
                      jint useEnvironment,
@@ -356,9 +358,15 @@ void pyembed_startup(JNIEnv *env,
 
     PyStatus status = PyStatus_Ok();
     PyConfig config;
-    PyConfig_InitPythonConfig(&config);
+    if (isolated) {
+        PyConfig_InitIsolatedConfig(&config);
+    } else {
+        PyConfig_InitPythonConfig(&config);
+    }
     // According to PEP-587 the fields shared with PyPreConfig should be set first.
-    config.parse_argv = 0;
+    if (parseArgv >= 0) {
+        config.parse_argv = 0;
+    }
     if (useEnvironment >= 0) {
         config.use_environment = useEnvironment;
     }

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -365,7 +365,7 @@ void pyembed_startup(JNIEnv *env,
     }
     // According to PEP-587 the fields shared with PyPreConfig should be set first.
     if (parseArgv >= 0) {
-        config.parse_argv = 0;
+        config.parse_argv = parseArgv;
     }
     if (useEnvironment >= 0) {
         config.use_environment = useEnvironment;

--- a/src/main/java/jep/MainInterpreter.java
+++ b/src/main/java/jep/MainInterpreter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2022 JEP AUTHORS.
+ * Copyright (c) 2015-2025 JEP AUTHORS.
  *
  * This file is licensed under the the zlib/libpng License.
  *
@@ -135,10 +135,11 @@ public final class MainInterpreter implements AutoCloseable {
         }
 
         if (pyConfig == null) {
-            pyConfig = new PyConfig();
+            pyConfig = PyConfig.python();
         }
         if (sharedModulesArgv != null) {
             pyConfig.setArgv(sharedModulesArgv);
+            pyConfig.setParseArgv(false);
         }
 
         thread = new Thread("JepMainInterpreter") {
@@ -146,9 +147,10 @@ public final class MainInterpreter implements AutoCloseable {
             @Override
             public void run() {
                 try {
-                    initializePython(pyConfig.argv, pyConfig.hashSeed,
-                            pyConfig.useHashSeed, pyConfig.home,
-                            pyConfig.optimizationLevel, pyConfig.programName,
+                    initializePython(pyConfig.isolated, pyConfig.argv,
+                            pyConfig.hashSeed, pyConfig.useHashSeed,
+                            pyConfig.home, pyConfig.optimizationLevel,
+                            pyConfig.parseArgv, pyConfig.programName,
                             pyConfig.siteImport, pyConfig.useEnvironment,
                             pyConfig.userSiteDirectory, pyConfig.verbose,
                             pyConfig.writeBytecode);
@@ -299,10 +301,11 @@ public final class MainInterpreter implements AutoCloseable {
         jepLibraryPath = path;
     }
 
-    private static native void initializePython(String[] argv, int hashSeed,
-            int useHashSeed, String home, int optimizationLevel,
-            String programName, int siteImport, int useEnvironment,
-            int userSiteDirectory, int verbose, int writeBytecode);
+    private static native void initializePython(boolean isolated, String[] argv,
+            int hashSeed, int useHashSeed, String home, int optimizationLevel,
+            int parseArgv, String programName, int siteImport,
+            int useEnvironment, int userSiteDirectory, int verbose,
+            int writeBytecode);
 
     private static native void sharedImportInternal(String module)
             throws JepException;

--- a/src/main/java/jep/PyConfig.java
+++ b/src/main/java/jep/PyConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2024 JEP AUTHORS.
+ * Copyright (c) 2016-2025 JEP AUTHORS.
  *
  * This file is licensed under the the zlib/libpng License.
  *
@@ -48,6 +48,8 @@ import java.util.Arrays;
  */
 public class PyConfig {
 
+    protected final boolean isolated;
+
     /*
      * -1 is used to indicate not set, in which case we will not set it in the
      * native code and the setting will be Python's default. A value of 0 or
@@ -64,6 +66,8 @@ public class PyConfig {
 
     protected int optimizationLevel = -1;
 
+    protected int parseArgv = -1;
+
     protected String programName;
 
     protected int siteImport = -1;
@@ -75,6 +79,18 @@ public class PyConfig {
     protected int verbose = -1;
 
     protected int writeBytecode = -1;
+
+    /**
+     * @deprecated Use {@link #python()} or {@link #isolated} instead.
+     */
+    @Deprecated
+    public PyConfig() {
+        this(false);
+    }
+
+    protected PyConfig(boolean isolated) {
+        this.isolated = isolated;
+    }
 
     /**
      * Set sys.argv for {@link SharedInterpreter}s and shared modules used by
@@ -148,6 +164,21 @@ public class PyConfig {
      */
     public PyConfig setOptimizationLevel(int optimizationLevel) {
         this.optimizationLevel = optimizationLevel;
+        return this;
+    }
+
+    /**
+     * If true, parse argv the same way the regular Python parses command line
+     * arguments, and strip Python arguments from argv.
+     * 
+     * @param parseArgv
+     *            a boolean to indicate whether python should parse command line
+     *            arguments
+     * @return a reference to this PyConfig
+     * @see https://docs.python.org/3/c-api/init_config.html#c.PyConfig.parse_argv
+     */
+    public PyConfig setParseArgv(boolean parseArgv) {
+        this.parseArgv = parseArgv ? 1 : 0;
         return this;
     }
 
@@ -370,15 +401,36 @@ public class PyConfig {
         return this.setHome(pythonHome);
     }
 
+    /**
+     * Create a new PyConfig with the default settings to behave as the regular
+     * Python.
+     * 
+     * @see https://docs.python.org/3/c-api/init_config.html#python-configuration
+     */
+    public static PyConfig python() {
+        return new PyConfig(false);
+    }
+
+    /**
+     * Create a new PyConfig with the default settings to isolate python from
+     * the rest of the system.
+     * 
+     * @see https://docs.python.org/3/c-api/init_config.html#isolated-configuration
+     */
+    public static PyConfig isolated() {
+        return new PyConfig(true);
+    }
+
     @Override
     public String toString() {
-        return "PyConfig [argv=" + Arrays.toString(argv) + ", hashSeed="
-                + hashSeed + ", useHashSeed=" + useHashSeed + ", home=" + home
-                + ", optimizationLevel=" + optimizationLevel + ", programName="
-                + programName + ", siteImport=" + siteImport
-                + ", useEnvironment=" + useEnvironment + ", userSiteDirectory="
-                + userSiteDirectory + ", verbose=" + verbose
-                + ", writeBytecode=" + writeBytecode + "]";
+        return "PyConfig [isolated=" + isolated + ", argv="
+                + Arrays.toString(argv) + ", hashSeed=" + hashSeed
+                + ", useHashSeed=" + useHashSeed + ", home=" + home
+                + ", optimizationLevel=" + optimizationLevel + ", parseArgv="
+                + parseArgv + ", programName=" + programName + ", siteImport="
+                + siteImport + ", useEnvironment=" + useEnvironment
+                + ", userSiteDirectory=" + userSiteDirectory + ", verbose="
+                + verbose + ", writeBytecode=" + writeBytecode + "]";
     }
 
 }

--- a/src/test/java/jep/test/TestPreInitVariables.java
+++ b/src/test/java/jep/test/TestPreInitVariables.java
@@ -25,7 +25,7 @@ import jep.SharedInterpreter;
 public class TestPreInitVariables {
 
     public static void main(String[] args) throws JepException {
-        PyConfig pyConfig = new PyConfig();
+        PyConfig pyConfig = PyConfig.python();
         // pyConfig.setIgnoreEnvironmentFlag(1);
         // TODO fix test so no site flag can be tested
         // pyConfig.setNoSiteFlag(1);

--- a/src/test/java/jep/test/TestSharedArgv.java
+++ b/src/test/java/jep/test/TestSharedArgv.java
@@ -24,7 +24,8 @@ public class TestSharedArgv {
     public static void main(String[] args) throws JepException {
 
         final String[] argv = new String[] { "", "-h", "other" };
-        MainInterpreter.setInitParams(new PyConfig().setArgv(argv));
+        MainInterpreter.setInitParams(
+                PyConfig.python().setArgv(argv).setParseArgv(false));
         JepConfig cfg = new JepConfig();
         cfg.addSharedModules("logging");
         cfg.addIncludePaths(".");


### PR DESCRIPTION
This builds on the changes in #586 and further improves the compatibility with the c-api. In that change I hardcoded the option to disable argv parsing however there may be use cases where someone wants to enable that parsing. To keep things consistent with the c-api the option is exposed in Java and Jep will no longer set the value of that option unless it is set in Java.

This also exposes the ability to create an isolated python configuration. For backwards compatibility the default is to use a config which behaves like regular python but the c-api includes a function to create an isolated python so I thought it would be useful to allow that option in Java.