### PR TITLE
Fix cases where startup errors can cause crashes.

### DIFF
--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -216,7 +216,7 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
     PyObject *sysmodules = PyImport_GetModuleDict();
     PyObject *modjep = PyDict_GetItemString(sysmodules, "_jep");
     if (!modjep && PyErr_Occurred()) {
-        handle_startup_exception(env, "Error checking for exisitng module _jep", 1);
+        handle_startup_exception(env, "Error checking for existing module _jep", 1);
     } else if (!modjep) {
         modjep = PyModule_Create(&jep_module_def);
         if (!modjep) {

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -72,7 +72,7 @@ static PyObject* mainThreadModules = NULL;
 static PyObject* mainThreadModulesLock = NULL;
 
 static int pyembed_is_version_unsafe(void);
-static void handle_startup_exception(JNIEnv*, const char*);
+static void handle_startup_exception(JNIEnv*, const char*, int);
 
 static PyObject* pyembed_findclass(PyObject*, PyObject*);
 static PyObject* pyembed_forname(PyObject*, PyObject*);
@@ -216,16 +216,16 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
     PyObject *sysmodules = PyImport_GetModuleDict();
     PyObject *modjep = PyDict_GetItemString(sysmodules, "_jep");
     if (!modjep && PyErr_Occurred()) {
-        handle_startup_exception(env, "Error checking for exisitng module _jep");
+        handle_startup_exception(env, "Error checking for exisitng module _jep", 1);
     } else if (!modjep) {
         modjep = PyModule_Create(&jep_module_def);
         if (!modjep) {
-            handle_startup_exception(env, "Couldn't create module _jep");
+            handle_startup_exception(env, "Couldn't create module _jep", 1);
             return -1;
         }
         if (PyDict_SetItemString(sysmodules, "_jep", modjep) == -1) {
             Py_DECREF(modjep);
-            handle_startup_exception(env, "Couldn't set _jep on sys.modules");
+            handle_startup_exception(env, "Couldn't set _jep on sys.modules", 1);
             return -1;
         }
         PyModule_AddStringConstant(modjep, "JBOOLEAN_ID", "z");
@@ -259,7 +259,7 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
         }
         if (pyjtypes_ready(modjep)) {
             Py_DECREF(modjep);
-            handle_startup_exception(env, "Failed to initialize PyJTypes");
+            handle_startup_exception(env, "Failed to initialize PyJTypes", 1);
             return -1;
         }
 
@@ -274,10 +274,11 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
     return 0;
 }
 
-static void handle_startup_exception(JNIEnv *env, const char* excMsg)
+static void handle_startup_exception(JNIEnv *env, const char* excMsg,
+                                     int checkpy)
 {
     jclass excClass = (*env)->FindClass(env, "java/lang/IllegalStateException");
-    if (PyErr_Occurred()) {
+    if (checkpy && PyErr_Occurred()) {
         PyErr_Print();
     }
     if (excClass != NULL) {
@@ -434,10 +435,7 @@ void pyembed_startup(JNIEnv *env,
     }
     PyConfig_Clear(&config);
     if (PyStatus_Exception(status)) {
-        jclass excClass = (*env)->FindClass(env, "java/lang/IllegalStateException");
-        if (excClass != NULL) {
-            (*env)->ThrowNew(env, excClass, status.err_msg);
-        }
+        handle_startup_exception(env, status.err_msg, 0);
         // The exit code is ignored, because exiting seems rude.
         return;
     }
@@ -448,31 +446,31 @@ void pyembed_startup(JNIEnv *env,
      */
     sysModule = PyImport_ImportModule("sys");
     if (sysModule == NULL) {
-        handle_startup_exception(env, "Failed to import sys module");
+        handle_startup_exception(env, "Failed to import sys module", 1);
         return;
     }
 
     mainThreadModules = PyObject_GetAttrString(sysModule, "modules");
     if (mainThreadModules == NULL) {
-        handle_startup_exception(env, "Failed to get sys.modules");
+        handle_startup_exception(env, "Failed to get sys.modules", 1);
         return;
     }
     Py_DECREF(sysModule);
 
     threadingModule = PyImport_ImportModule("threading");
     if (threadingModule == NULL) {
-        handle_startup_exception(env, "Failed to import threading module");
+        handle_startup_exception(env, "Failed to import threading module", 1);
         return;
     }
     lockCreator = PyObject_GetAttrString(threadingModule, "Lock");
     if (lockCreator == NULL) {
-        handle_startup_exception(env, "Failed to get Lock attribute");
+        handle_startup_exception(env, "Failed to get Lock attribute", 1);
         return;
     }
 
     mainThreadModulesLock = PyObject_CallObject(lockCreator, NULL);
     if (mainThreadModulesLock == NULL) {
-        handle_startup_exception(env, "Failed to get main thread modules lock");
+        handle_startup_exception(env, "Failed to get main thread modules lock", 1);
         return;
     }
     Py_DECREF(threadingModule);
@@ -522,7 +520,7 @@ int pyembed_is_version_unsafe(void)
         sprintf(msg,
                 "Jep will not initialize because it was compiled against Python %i.%i but is running against Python %s.%s",
                 PY_MAJOR_VERSION, PY_MINOR_VERSION, major, minor);
-        THROW_JEP(env, msg);
+        handle_startup_exception(env, msg, 0);
         free(version);
         free(msg);
         return 1;
@@ -583,7 +581,7 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
     JepThread *jepThread;
     PyObject  *tdict, *globals;
     if (cl == NULL) {
-        THROW_JEP(env, "Invalid Classloader.");
+        handle_startup_exception(env, "Invalid Classloader.", 0);
         return 0;
     }
 
@@ -595,7 +593,7 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
      */
     jepThread = malloc(sizeof(JepThread));
     if (!jepThread) {
-        THROW_JEP(env, "Out of memory.");
+        handle_startup_exception(env, "Out of memory.", 0);
         return 0;
     }
 
@@ -634,8 +632,9 @@ intptr_t pyembed_thread_init(JNIEnv *env, jobject cl, jobject caller,
         }
         PyStatus status = Py_NewInterpreterFromConfig(&(jepThread->tstate), &config);
         if (PyStatus_Exception(status)) {
-            THROW_JEP(env, status.err_msg);
+            handle_startup_exception(env, status.err_msg, 0);
             free(jepThread);
+            PyEval_ReleaseThread(mainThreadState);
             return 0;
         }
 #else

--- a/src/test/java/jep/test/TestSubInterpOptions.java
+++ b/src/test/java/jep/test/TestSubInterpOptions.java
@@ -12,15 +12,18 @@ public class TestSubInterpOptions {
     private String failure;
 
     public boolean testForbidFork() {
-        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowFork(false);
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setAllowFork(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
         try (Interpreter interp = new SubInterpreter(config)) {
             interp.exec("import os");
             interp.exec("os.fork()");
             failure = "Fork should not be allowed";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().contains("fork not supported for isolated subinterpreters")) {
+            if (e.getMessage().contains(
+                    "fork not supported for isolated subinterpreters")) {
                 return true;
             }
             failure = e.getMessage();
@@ -29,15 +32,18 @@ public class TestSubInterpOptions {
     }
 
     public boolean testForbidExec() {
-        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowExec(false);
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setAllowExec(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
         try (Interpreter interp = new SubInterpreter(config)) {
             interp.exec("import os");
             interp.exec("os.execv('/bin/ls', [])");
             failure = "Exec should not be allowed";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().contains("exec not supported for isolated subinterpreters")) {
+            if (e.getMessage().contains(
+                    "exec not supported for isolated subinterpreters")) {
                 return true;
             }
             failure = e.getMessage();
@@ -46,15 +52,18 @@ public class TestSubInterpOptions {
     }
 
     public boolean testForbidThreads() {
-        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowThreads(false);
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setAllowThreads(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
         try (Interpreter interp = new SubInterpreter(config)) {
             interp.exec("import threading");
             interp.exec("threading.Thread(target=print).start()");
             failure = "Thread should not be allowed";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().contains("thread is not supported for isolated subinterpreters")) {
+            if (e.getMessage().contains(
+                    "thread is not supported for isolated subinterpreters")) {
                 return true;
             }
             failure = e.getMessage();
@@ -63,15 +72,18 @@ public class TestSubInterpOptions {
     }
 
     public boolean testForbidDaemonThreads() {
-        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setAllowDaemonThreads(false);
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setAllowDaemonThreads(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
         try (Interpreter interp = new SubInterpreter(config)) {
             interp.exec("import threading");
             interp.exec("threading.Thread(target=print, daemon=True).start()");
             failure = "Daemon Thread should not be allowed";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().contains("daemon threads are disabled in this (sub)interpreter")) {
+            if (e.getMessage().contains(
+                    "daemon threads are disabled in this (sub)interpreter")) {
                 return true;
             }
             failure = e.getMessage();
@@ -80,17 +92,20 @@ public class TestSubInterpOptions {
     }
 
     /**
-     * We can't actually verify the correct malloc is used but we do ned to
+     * We can't actually verify the correct malloc is used but we do need to
      * verify shared modules can't be mixed with isolated malloc.
      */
     public boolean testUseMainObmalloc() {
-        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy().setUseMainObmalloc(false);
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions).addSharedModules("os");
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setUseMainObmalloc(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions).addSharedModules("os");
         try (Interpreter interp = new SubInterpreter(config)) {
             failure = "Shared modules can only be used with a shared allocator.";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().equals("Shared modules can only be used with a shared allocator.")) {
+            if (e.getMessage().equals(
+                    "Shared modules can only be used with a shared allocator.")) {
                 return true;
             }
             failure = e.getMessage();
@@ -100,7 +115,8 @@ public class TestSubInterpOptions {
 
     public boolean testIsolated() {
         SubInterpreterOptions interpOptions = SubInterpreterOptions.isolated();
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
         try (Interpreter interp = new SubInterpreter(config)) {
             interp.exec("from java.lang import Object");
             // I have no way to check if the interpreter is actually isolated so
@@ -114,12 +130,14 @@ public class TestSubInterpOptions {
 
     public boolean testIsolatedWithSharedModule() {
         SubInterpreterOptions interpOptions = SubInterpreterOptions.isolated();
-        JepConfig config = new JepConfig().setSubInterpreterOptions(interpOptions).addSharedModules("os");
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions).addSharedModules("os");
         try (Interpreter interp = new SubInterpreter(config)) {
             failure = "Shared modules cannot be used with isolated interpreters.";
             return false;
         } catch (JepException e) {
-            if (e.getMessage().equals("Shared modules cannot be used with isolated interpreters.")) {
+            if (e.getMessage().equals(
+                    "Shared modules cannot be used with isolated interpreters.")) {
                 return true;
             }
             failure = e.getMessage();
@@ -127,6 +145,30 @@ public class TestSubInterpOptions {
         }
     }
 
+    /**
+     * When Python detects a invalid config and reports an error then jep should
+     * convert the error to a java exception. This relies on Python detecting
+     * that setUseMainObmalloc(false) must be used with
+     * setCheckMultiInterpExtensions(true). If Python ever relaxes this
+     * restriction or changes the error message the test will need to be
+     * updated.
+     */
+    public boolean testInvalidOptionsThrowsException() {
+        SubInterpreterOptions interpOptions = SubInterpreterOptions.legacy()
+                .setUseMainObmalloc(false);
+        JepConfig config = new JepConfig()
+                .setSubInterpreterOptions(interpOptions);
+        try (Interpreter interp = new SubInterpreter(config)) {
+            failure = "per-interpreter obmalloc does not support single-phase init extension modules.";
+            return false;
+        } catch (IllegalStateException e) {
+            if (e.getMessage().contains("obmalloc does not support")) {
+                return true;
+            }
+            failure = e.getMessage();
+            return false;
+        }
+    }
 
     public void runTest() {
         if (!testForbidFork()) {
@@ -150,15 +192,17 @@ public class TestSubInterpOptions {
         if (!testIsolatedWithSharedModule()) {
             return;
         }
+        if (!testInvalidOptionsThrowsException()) {
+            return;
+        }
     }
 
-    public static String test() throws InterruptedException{
+    public static String test() throws InterruptedException {
         TestSubInterpOptions test = new TestSubInterpOptions();
         Thread t = new Thread(test::runTest);
         t.start();
         t.join();
         return test.failure;
     }
-
 
 }


### PR DESCRIPTION
Using invalid SubInterpreterOptions was causing a crash rather than throwing an exception even though we have checks to throw an exception. It turns out we were trying to throw a JepException before initializing the variable that holds JepException is initialized. We have an existing function to handle startup errors before JepException is available but that function checks for python exceptions and errors during python initialization probably shouldn't use the python APIs. This change makes the python error check optional in `handle_startup_exception` and changes any startup errors that use `THROW_JEP` to use `handle_startup_exception` instead.