### PR TITLE
Convert all types to heap types.

### DIFF
--- a/src/main/c/Include/pyembed.h
+++ b/src/main/c/Include/pyembed.h
@@ -43,9 +43,20 @@ struct __JepThread {
 typedef struct __JepThread JepThread;
 
 struct __JepModuleState {
+    PyObject *pyJTypeCache;
+
+    PyTypeObject *PyJType_Type;
+    PyTypeObject *PyJField_Type;
+    PyTypeObject *PyJMethod_Type;
+    PyTypeObject *PyJConstructor_Type;
+    PyTypeObject *PyJMultiMethod_Type;
+
     PyTypeObject *PyJObject_Type;
     PyTypeObject *PyJClass_Type;
     PyTypeObject *PyJArray_Type;
+
+    PyTypeObject *PyJMonitor_Type;
+    PyTypeObject *PyJArrayIter_Type;
 };
 typedef struct __JepModuleState JepModuleState;
 

--- a/src/main/c/Include/pyjarray.h
+++ b/src/main/c/Include/pyjarray.h
@@ -33,6 +33,7 @@
 
 
 extern PyType_Spec PyJArray_Spec;
+extern PyType_Spec PyJArrayIter_Spec;
 
 // c storage for our stuff, managed by python interpreter.
 typedef struct {

--- a/src/main/c/Include/pyjconstructor.h
+++ b/src/main/c/Include/pyjconstructor.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2016-2022 JEP AUTHORS.
+   Copyright (c) 2016-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -31,11 +31,9 @@
 #ifndef _Included_pyjconstructor
 #define _Included_pyjconstructor
 
-extern PyTypeObject PyJConstructor_Type;
+extern PyType_Spec PyJConstructor_Spec;
 
 /* Second arg must be a java.lang.reflect.Constructor */
-PyObject* PyJConstructor_New(JNIEnv*, jobject);
-
-int PyJConstructor_Check(PyObject*);
+PyObject* PyJConstructor_New(JNIEnv*, JepModuleState*, jobject);
 
 #endif // ndef pyjconstructor

--- a/src/main/c/Include/pyjfield.h
+++ b/src/main/c/Include/pyjfield.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -31,7 +31,7 @@
 #ifndef _Included_pyjfield
 #define _Included_pyjfield
 
-extern PyTypeObject PyJField_Type;
+extern PyType_Spec PyJField_Spec;
 
 /* Represents a java field on a java object and allows getting and setting values */
 typedef struct {
@@ -47,8 +47,8 @@ typedef struct {
 } PyJFieldObject;
 
 
-PyJFieldObject* PyJField_New(JNIEnv*, jobject);
-int PyJField_Check(PyObject*);
+PyJFieldObject* PyJField_New(JNIEnv*, JepModuleState*, jobject);
+int PyJField_Check(JepModuleState*, PyObject*);
 
 PyObject* pyjfield_get(PyJFieldObject*, PyJObject*);
 int pyjfield_set(PyJFieldObject*, PyJObject*, PyObject*);

--- a/src/main/c/Include/pyjmethod.h
+++ b/src/main/c/Include/pyjmethod.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2004-2022 JEP AUTHORS.
+   Copyright (c) 2004-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -32,7 +32,7 @@
 #define _Included_pyjmethod
 
 
-extern PyTypeObject PyJMethod_Type;
+extern PyType_Spec PyJMethod_Spec;
 
 /*
  * A callable python object which wraps a java method and is dynamically added
@@ -54,10 +54,10 @@ typedef struct {
 } PyJMethodObject;
 
 /* Create a new PyJMethod from a java.lang.reflect.Method*/
-PyJMethodObject* PyJMethod_New(JNIEnv*, jobject);
+PyJMethodObject* PyJMethod_New(JNIEnv*, JepModuleState*, jobject);
 
 /* Check if the arg is a PyJMethodObject */
-int PyJMethod_Check(PyObject *obj);
+int PyJMethod_Check(JepModuleState*, PyObject *obj);
 
 /*
  * Get the number of parameters the method is expecting. If the method has not
@@ -68,7 +68,7 @@ int PyJMethod_GetParameterCount(PyJMethodObject*, JNIEnv*);
 /*
  * Check if a method is compatible with the types of a tuple of arguments.
  * This will return a 0 if the arguments are not valid for this method and a
- * positive integer if the arguments are valid. Returns a negative value on error. 
+ * positive integer if the arguments are valid. Returns a negative value on error.
  * Larger numbers indicate a better match between the arguments and the expected parameter types.
  * This function uses pyarg_matches_jtype to determine how well arguments match.
  * This function does not need to be called before using calling this method, it is only

--- a/src/main/c/Include/pyjmonitor.h
+++ b/src/main/c/Include/pyjmonitor.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2017-2022 JEP AUTHORS.
+   Copyright (c) 2017-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -37,7 +37,7 @@
 #ifndef _Included_pyjmonitor
 #define _Included_pyjmonitor
 
-extern PyTypeObject PyJMonitor_Type;
+extern PyType_Spec PyJMonitor_Spec;
 
 typedef struct {
     PyObject_HEAD
@@ -50,10 +50,5 @@ typedef struct {
  * synchronized on an object.
  */
 PyObject* PyJMonitor_New(jobject);
-
-/*
- * Returns true if the object is a PyJMonitor.
- */
-int PyJMonitor_Check(PyObject*);
 
 #endif // ndef pyjmonitor

--- a/src/main/c/Include/pyjmultimethod.h
+++ b/src/main/c/Include/pyjmultimethod.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2015-2022 JEP_AUTHORS.
+   Copyright (c) 2015-2025 JEP_AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -33,7 +33,7 @@
 #define _Included_pyjmultimethod
 
 
-extern PyTypeObject PyJMultiMethod_Type;
+extern PyType_Spec PyJMultiMethod_Spec;
 
 typedef struct {
     PyObject_HEAD
@@ -45,11 +45,11 @@ typedef struct {
  * make a PyJMultiMethod, after creation it is possible to add more than two
  * methods using PyJMultiMethod_Append.
  */
-PyObject* PyJMultiMethod_New(PyObject*, PyObject*);
+PyObject* PyJMultiMethod_New(JepModuleState*, PyObject*, PyObject*);
 /* Args must be a PyJMultiMethodObject and a PyJMethodObject */
-int PyJMultiMethod_Append(PyObject*, PyObject*);
+int PyJMultiMethod_Append(JepModuleState*, PyObject*, PyObject*);
 /* Check if the arg is a PyJMultiMethodObject */
-int PyJMultiMethod_Check(PyObject*);
+int PyJMultiMethod_Check(JepModuleState*, PyObject*);
 /* Get the name of a PyJMultiMethodObject, returns a new reference to the name */
 PyObject* PyJMultiMethod_GetName(PyObject*);
 

--- a/src/main/c/Include/pyjtype.h
+++ b/src/main/c/Include/pyjtype.h
@@ -1,7 +1,7 @@
 /*
    jep - Java Embedded Python
 
-   Copyright (c) 2020-2022 JEP AUTHORS.
+   Copyright (c) 2020-2025 JEP AUTHORS.
 
    This file is licensed under the the zlib/libpng License.
 
@@ -29,6 +29,8 @@
 
 #ifndef _Included_pyjtype
 #define _Included_pyjtype
+
+extern PyType_Spec PyJType_Spec;
 
 /*
  * Get a PyTypeObject for the java class provided.

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -313,7 +313,7 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             handle_startup_exception(env, "Failed to initialize PyJTypes", 1);
             return -1;
         }
-        Py_INCREF(modjep);
+        Py_INCREF(javaTypeCache);
         modState->pyJTypeCache = javaTypeCache;
 
         /* still held by sys.modules. */

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -158,13 +158,26 @@ static struct PyMethodDef jep_methods[] = {
     { NULL, NULL }
 };
 
+static void free_jep_module_state(JepModuleState* modState)
+{
+    Py_CLEAR(modState->pyJTypeCache);
+    Py_CLEAR(modState->PyJType_Type);
+    Py_CLEAR(modState->PyJField_Type);
+    Py_CLEAR(modState->PyJMethod_Type);
+    Py_CLEAR(modState->PyJConstructor_Type);
+    Py_CLEAR(modState->PyJMultiMethod_Type);
+    Py_CLEAR(modState->PyJObject_Type);
+    Py_CLEAR(modState->PyJClass_Type);
+    Py_CLEAR(modState->PyJArray_Type);
+    Py_CLEAR(modState->PyJMonitor_Type);
+    Py_CLEAR(modState->PyJArrayIter_Type);
+}
+
 static void free_jep_module(PyObject* modjep)
 {
     JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
     if (modState) {
-        Py_CLEAR(modState->PyJObject_Type);
-        Py_CLEAR(modState->PyJClass_Type);
-        Py_CLEAR(modState->PyJArray_Type);
+        free_jep_module_state(modState);
     }
 }
 
@@ -180,10 +193,34 @@ static struct PyModuleDef jep_module_def = {
     (freefunc) free_jep_module, /* m_free */
 };
 
-static int pyjtypes_ready(PyObject *modjep)
+static int pyjtypes_ready(JepModuleState* modState)
 {
-    JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
-    if (!modState) {
+    modState->PyJType_Type = (PyTypeObject*) PyType_FromSpecWithBases(&PyJType_Spec,
+                             (PyObject*) &PyType_Type);
+    if (!modState->PyJType_Type) {
+        free_jep_module_state(modState);
+        return -1;
+    }
+    modState->PyJField_Type = (PyTypeObject*) PyType_FromSpec(&PyJField_Spec);
+    if (!modState->PyJField_Type) {
+        free_jep_module_state(modState);
+        return -1;
+    }
+    modState->PyJMethod_Type = (PyTypeObject*) PyType_FromSpec(&PyJMethod_Spec);
+    if (!modState->PyJMethod_Type) {
+        free_jep_module_state(modState);
+        return -1;
+    }
+    modState->PyJConstructor_Type = (PyTypeObject*) PyType_FromSpecWithBases(
+                                        &PyJConstructor_Spec, (PyObject*) modState->PyJMethod_Type);
+    if (!modState->PyJConstructor_Type) {
+        free_jep_module_state(modState);
+        return -1;
+    }
+    modState->PyJMultiMethod_Type = (PyTypeObject*) PyType_FromSpec(
+                                        &PyJMultiMethod_Spec);
+    if (!modState->PyJMultiMethod_Type) {
+        free_jep_module_state(modState);
         return -1;
     }
     modState->PyJObject_Type = (PyTypeObject*) PyType_FromSpec(&PyJObject_Spec);
@@ -193,14 +230,22 @@ static int pyjtypes_ready(PyObject *modjep)
     modState->PyJClass_Type = (PyTypeObject*) PyType_FromSpecWithBases(
                                   &PyJClass_Spec, (PyObject*) modState->PyJObject_Type);
     if (!modState->PyJClass_Type) {
-        Py_CLEAR(modState->PyJObject_Type);
+        free_jep_module_state(modState);
         return -1;
     }
     modState->PyJArray_Type = (PyTypeObject*) PyType_FromSpecWithBases(
                                   &PyJArray_Spec, (PyObject*) modState->PyJObject_Type);
     if (!modState->PyJArray_Type) {
-        Py_CLEAR(modState->PyJObject_Type);
-        Py_CLEAR(modState->PyJClass_Type);
+        free_jep_module_state(modState);
+        return -1;
+    }
+    modState->PyJMonitor_Type = (PyTypeObject*) PyType_FromSpec(&PyJMonitor_Spec);
+    if (!modState->PyJMonitor_Type) {
+        return -1;
+    }
+    modState->PyJArrayIter_Type = (PyTypeObject*) PyType_FromSpec(
+                                      &PyJArrayIter_Spec);
+    if (!modState->PyJArrayIter_Type) {
         return -1;
     }
     return 0;
@@ -257,11 +302,19 @@ static int initjep(JNIEnv *env, jboolean hasSharedModules)
             Py_INCREF(mainThreadModulesLock);
             PyModule_AddObject(modjep, "mainInterpreterModulesLock", mainThreadModulesLock);
         }
-        if (pyjtypes_ready(modjep)) {
+        JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
+        if (!modState) {
+            Py_DECREF(modjep);
+            handle_startup_exception(env, "Failed to initialize module state", 1);
+            return -1;
+        }
+        if (pyjtypes_ready(modState)) {
             Py_DECREF(modjep);
             handle_startup_exception(env, "Failed to initialize PyJTypes", 1);
             return -1;
         }
+        Py_INCREF(modjep);
+        modState->pyJTypeCache = javaTypeCache;
 
         /* still held by sys.modules. */
         Py_DECREF(modjep);
@@ -441,7 +494,7 @@ void pyembed_startup(JNIEnv *env,
     }
 
     /*
-     * Save a global reference to the sys.modules form the main thread to
+     * Save a global reference to the sys.modules from the main thread to
      * support shared modules
      */
     sysModule = PyImport_ImportModule("sys");

--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -181,6 +181,25 @@ static void free_jep_module(PyObject* modjep)
     }
 }
 
+static int traverse_jep_module(PyObject* modjep, visitproc visit, void *arg)
+{
+    JepModuleState* modState = (JepModuleState*) PyModule_GetState(modjep);
+    if (modState) {
+        Py_VISIT(modState->pyJTypeCache);
+        Py_VISIT(modState->PyJType_Type);
+        Py_VISIT(modState->PyJField_Type);
+        Py_VISIT(modState->PyJMethod_Type);
+        Py_VISIT(modState->PyJConstructor_Type);
+        Py_VISIT(modState->PyJMultiMethod_Type);
+        Py_VISIT(modState->PyJObject_Type);
+        Py_VISIT(modState->PyJClass_Type);
+        Py_VISIT(modState->PyJArray_Type);
+        Py_VISIT(modState->PyJMonitor_Type);
+        Py_VISIT(modState->PyJArrayIter_Type);
+    }
+    return 0;
+}
+
 static struct PyModuleDef jep_module_def = {
     PyModuleDef_HEAD_INIT,
     "_jep",                     /* m_name */
@@ -188,7 +207,7 @@ static struct PyModuleDef jep_module_def = {
     sizeof(JepModuleState),     /* m_size */
     jep_methods,                /* m_methods */
     NULL,                       /* m_reload */
-    NULL,                       /* m_traverse */
+    traverse_jep_module,        /* m_traverse */
     NULL,                       /* m_clear */
     (freefunc) free_jep_module, /* m_free */
 };

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -1671,7 +1671,8 @@ static PyObject *pyjarray_iter(PyObject *seq)
     if (!modState) {
         return NULL;
     }
-    it = PyObject_New(PyJArrayIterObject, modState->PyJArrayIter_Type);
+    PyTypeObject* tp = modState->PyJArrayIter_Type;
+    it  = (PyJArrayIterObject*) tp->tp_alloc(tp, 0);
     if (it == NULL) {
         return NULL;
     }
@@ -1685,8 +1686,15 @@ static void pyjarrayiter_dealloc(PyJArrayIterObject *it)
 {
     PyTypeObject *tp = Py_TYPE(it);
     Py_XDECREF(it->it_seq);
-    PyObject_Del(it);
+    tp->tp_free((PyObject*) it);
     Py_DECREF(tp);
+}
+
+static int pyjarrayiter_traverse(PyJArrayIterObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->it_seq);
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 static PyObject *pyjarrayiter_next(PyJArrayIterObject *it)
@@ -1725,6 +1733,7 @@ static int pyjarrayiter_len(PyJArrayIterObject *it)
 
 static PyType_Slot iterslots[] = {
     {Py_tp_dealloc, pyjarrayiter_dealloc},
+    {Py_tp_traverse, pyjarrayiter_traverse},
     {Py_sq_length, pyjarrayiter_len},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, pyjarrayiter_next},
@@ -1734,6 +1743,6 @@ static PyType_Slot iterslots[] = {
 PyType_Spec PyJArrayIter_Spec = {
     .name = "jep.PyJArrayIter",
     .basicsize = sizeof(PyJArrayIterObject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = iterslots
 };

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -1683,8 +1683,10 @@ static PyObject *pyjarray_iter(PyObject *seq)
 
 static void pyjarrayiter_dealloc(PyJArrayIterObject *it)
 {
+    PyTypeObject *tp = Py_TYPE(it);
     Py_XDECREF(it->it_seq);
     PyObject_Del(it);
+    Py_DECREF(tp);
 }
 
 static PyObject *pyjarrayiter_next(PyJArrayIterObject *it)

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -1659,21 +1659,19 @@ typedef struct {
     PyJArrayObject *it_seq; /* Set to NULL when iterator is exhausted */
 } PyJArrayIterObject;
 
-PyTypeObject PyJArrayIter_Type;
-
 static PyObject *pyjarray_iter(PyObject *seq)
 {
     PyJArrayIterObject *it;
-
-    if (PyType_Ready(&PyJArrayIter_Type) < 0) {
-        return NULL;
-    }
 
     if (!pyjarray_check(seq)) {
         PyErr_BadInternalCall();
         return NULL;
     }
-    it = PyObject_New(PyJArrayIterObject, &PyJArrayIter_Type);
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return NULL;
+    }
+    it = PyObject_New(PyJArrayIterObject, modState->PyJArrayIter_Type);
     if (it == NULL) {
         return NULL;
     }
@@ -1723,51 +1721,17 @@ static int pyjarrayiter_len(PyJArrayIterObject *it)
     return 0;
 }
 
-static PySequenceMethods pyjarrayiter_as_sequence = {
-    (lenfunc) pyjarrayiter_len,               /* sq_length */
-    0,                                        /* sq_concat */
+static PyType_Slot iterslots[] = {
+    {Py_tp_dealloc, pyjarrayiter_dealloc},
+    {Py_sq_length, pyjarrayiter_len},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, pyjarrayiter_next},
+    {0, NULL},
 };
 
-PyObject* pyjarrayiter_getattr(PyObject *one, PyObject *two)
-{
-    return PyObject_GenericGetAttr(one, two);
-}
-
-PyTypeObject PyJArrayIter_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJArrayIter",                       /* tp_name */
-    sizeof(PyJArrayIterObject),               /* tp_basicsize */
-    0,                                        /* tp_itemsize */
-    /* methods */
-    (destructor) pyjarrayiter_dealloc,        /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    &pyjarrayiter_as_sequence,                /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    (getattrofunc) pyjarrayiter_dealloc,      /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    0,                                        /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    PyObject_SelfIter,                        /* tp_iter */
-    (iternextfunc) pyjarrayiter_next,         /* tp_iternext */
-    0,                                        /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0, // &PyJObject_Type                     /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
+PyType_Spec PyJArrayIter_Spec = {
+    .name = "jep.PyJArrayIter",
+    .basicsize = sizeof(PyJArrayIterObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = iterslots
 };

--- a/src/main/c/Objects/pyjarray.c
+++ b/src/main/c/Objects/pyjarray.c
@@ -1684,6 +1684,7 @@ static PyObject *pyjarray_iter(PyObject *seq)
 
 static void pyjarrayiter_dealloc(PyJArrayIterObject *it)
 {
+    PyObject_GC_UnTrack(it);
     PyTypeObject *tp = Py_TYPE(it);
     Py_XDECREF(it->it_seq);
     tp->tp_free((PyObject*) it);

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -155,7 +155,8 @@ static PyObject* pyjclass_add_inner_classes(JNIEnv *env,
  * is cached, this can just copy the attributes from the type and avoid any
  * reflection.
  */
-static PyObject* pyjclass_init_attr(JNIEnv *env, jclass clazz)
+static PyObject* pyjclass_init_attr(JNIEnv *env, JepModuleState *modState,
+                                    jclass clazz)
 {
     PyObject *attr = PyDict_New();
     if (!attr) {
@@ -177,8 +178,8 @@ static PyObject* pyjclass_init_attr(JNIEnv *env, jclass clazz)
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(type->tp_dict, &pos, &key, &value)) {
-        if (PyJMethod_Check(value) || PyJMultiMethod_Check(value)
-                || PyJField_Check(value) ) {
+        if (PyJMethod_Check(modState, value) || PyJMultiMethod_Check(modState, value)
+                || PyJField_Check(modState, value) ) {
             if (PyDict_SetItem(attr, key, value) != 0) {
                 Py_DecRef((PyObject*) type);
                 Py_DecRef(attr);
@@ -190,12 +191,12 @@ static PyObject* pyjclass_init_attr(JNIEnv *env, jclass clazz)
     return attr;
 }
 
-static int pyjclass_init(JNIEnv *env, PyObject *pyobj)
+static int pyjclass_init(JNIEnv *env, JepModuleState *modState, PyObject *pyobj)
 {
     PyJClassObject *pyjclass = (PyJClassObject*) pyobj;
 
     pyjclass->constructor = NULL;
-    pyjclass->attr = pyjclass_init_attr(env, ((PyJObject*) pyobj)->clazz);
+    pyjclass->attr = pyjclass_init_attr(env, modState, ((PyJObject*) pyobj)->clazz);
     if (pyjclass->attr == NULL) {
         return 0;
     }
@@ -226,7 +227,7 @@ PyObject* PyJClass_Wrap(JNIEnv *env, jobject obj)
     }
     PyObject* pyjob = PyJObject_New(env, modState->PyJClass_Type, NULL, obj);
     if (pyjob) {
-        if (!pyjclass_init(env, pyjob)) {
+        if (!pyjclass_init(env, modState, pyjob)) {
             Py_DecRef(pyjob);
             pyjob = NULL;
         }
@@ -262,6 +263,11 @@ static int pyjclass_init_constructors(PyJClassObject *pyc)
         return -1;
     }
 
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return -1;
+    }
+
     initArray = java_lang_Class_getConstructors(env, pyc->clazz);
     if (process_java_exception(env) || !initArray) {
         goto EXIT_ERROR;
@@ -277,7 +283,7 @@ static int pyjclass_init_constructors(PyJClassObject *pyc)
         if (process_java_exception(env) || !constructor) {
             goto EXIT_ERROR;
         }
-        pyjinit = PyJConstructor_New(env, constructor);
+        pyjinit = PyJConstructor_New(env, modState, constructor);
         if (pyjinit == NULL) {
             goto EXIT_ERROR;
         }
@@ -287,14 +293,14 @@ static int pyjclass_init_constructors(PyJClassObject *pyc)
             pycallable = pyjinit;
         } else if (i == 1) {
             PyObject* firstInit = pycallable;
-            pycallable = PyJMultiMethod_New(firstInit, pyjinit);
+            pycallable = PyJMultiMethod_New(modState, firstInit, pyjinit);
             Py_DECREF(firstInit);
             Py_DECREF(pyjinit);
             if (pycallable == NULL) {
                 goto EXIT_ERROR;
             }
         } else {
-            if (PyJMultiMethod_Append(pycallable, pyjinit) == -1) {
+            if (PyJMultiMethod_Append(modState, pycallable, pyjinit) == -1) {
                 Py_DECREF(pyjinit);
                 goto EXIT_ERROR;
             }
@@ -350,7 +356,12 @@ static PyObject* pyjclass_getattro(PyObject *obj, PyObject *name)
     PyObject *ret = PyObject_GenericGetAttr(obj, name);
     if (ret == NULL) {
         return NULL;
-    } else if (PyJMethod_Check(ret) || PyJMultiMethod_Check(ret)) {
+    }
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return NULL;
+    }
+    if (PyJMethod_Check(modState, ret) || PyJMultiMethod_Check(modState, ret)) {
         /*
          * TODO Should not bind non-static methods to pyjclass objects, but not
          * sure yet how to handle multimethods and static methods.
@@ -358,7 +369,7 @@ static PyObject* pyjclass_getattro(PyObject *obj, PyObject *name)
         PyObject* wrapper = PyMethod_New(ret, (PyObject*) obj);
         Py_DECREF(ret);
         return wrapper;
-    } else if (PyJField_Check(ret)) {
+    } else if (PyJField_Check(modState, ret)) {
         PyObject *resolved = pyjfield_get((PyJFieldObject *) ret, (PyJObject*) obj);
         Py_DECREF(ret);
         return resolved;
@@ -392,9 +403,13 @@ static int pyjclass_setattro(PyObject *obj, PyObject *name, PyObject *v)
         return -1;
     }
 
-    if (!PyJField_Check(cur)) {
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
+        return -1;
+    }
+    if (!PyJField_Check(modState, cur)) {
         PyObject* javaClassName = PyObject_GetAttrString(obj, "java_name");
-        if (PyJMethod_Check(cur) || PyJMultiMethod_Check(cur)) {
+        if (PyJMethod_Check(modState, cur) || PyJMultiMethod_Check(modState, cur)) {
             PyErr_Format(PyExc_AttributeError, "'%s' object cannot assign to method '%s'.",
                          PyUnicode_AsUTF8(javaClassName), PyUnicode_AsUTF8(name));
         } else {

--- a/src/main/c/Objects/pyjclass.c
+++ b/src/main/c/Objects/pyjclass.c
@@ -265,7 +265,7 @@ static int pyjclass_init_constructors(PyJClassObject *pyc)
 
     JepModuleState* modState = pyembed_get_module_state();
     if (!modState) {
-        return -1;
+        goto EXIT_ERROR;
     }
 
     initArray = java_lang_Class_getConstructors(env, pyc->clazz);

--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -89,7 +89,8 @@ PyObject* PyJConstructor_New(JNIEnv *env, JepModuleState *modState,
 {
     PyJMethodObject* pym = NULL;
 
-    pym = PyObject_NEW(PyJMethodObject, modState->PyJConstructor_Type);
+    PyTypeObject *tp = modState->PyJConstructor_Type;
+    pym = (PyJMethodObject*) tp->tp_alloc(tp, 0);
     pym->rmethod       = (*env)->NewGlobalRef(env, constructor);
     pym->parameters    = NULL;
     pym->lenParameters = 0;

--- a/src/main/c/Objects/pyjconstructor.c
+++ b/src/main/c/Objects/pyjconstructor.c
@@ -84,21 +84,12 @@ EXIT_ERROR:
 }
 
 
-PyObject* PyJConstructor_New(JNIEnv *env, jobject constructor)
+PyObject* PyJConstructor_New(JNIEnv *env, JepModuleState *modState,
+                             jobject constructor)
 {
     PyJMethodObject* pym = NULL;
 
-    if (PyType_Ready(&PyJMethod_Type) < 0) {
-        return NULL;
-    }
-    if (!PyJConstructor_Type.tp_base) {
-        PyJConstructor_Type.tp_base = &PyJMethod_Type;
-    }
-    if (PyType_Ready(&PyJConstructor_Type) < 0) {
-        return NULL;
-    }
-
-    pym = PyObject_NEW(PyJMethodObject, &PyJConstructor_Type);
+    pym = PyObject_NEW(PyJMethodObject, modState->PyJConstructor_Type);
     pym->rmethod       = (*env)->NewGlobalRef(env, constructor);
     pym->parameters    = NULL;
     pym->lenParameters = 0;
@@ -123,11 +114,6 @@ PyObject* PyJConstructor_New(JNIEnv *env, jobject constructor)
     }
 
     return (PyObject*) pym;
-}
-
-int PyJConstructor_Check(PyObject* object)
-{
-    return PyObject_TypeCheck(object, &PyJConstructor_Type);
 }
 
 
@@ -319,45 +305,15 @@ EXIT_ERROR:
     return NULL;
 }
 
+static PyType_Slot slots[] = {
+    {Py_tp_doc, "jconstructor"},
+    {Py_tp_call, pyjconstructor_call},
+    {0, NULL},
+};
 
-PyTypeObject PyJConstructor_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJConstructor",
-    sizeof(PyJMethodObject),
-    0,
-    0,                                       /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    (ternaryfunc) pyjconstructor_call,        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    "jconstructor",                           /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    0,                                        /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0, // &PyJMethod_Type                     /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+PyType_Spec PyJConstructor_Spec = {
+    .name = "jep.PyJConstructor",
+    .basicsize = sizeof(PyJMethodObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = slots
 };

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -36,6 +36,7 @@
 static void pyjfield_dealloc(PyJFieldObject *self)
 {
 #if USE_DEALLOC
+    PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env  = pyembed_get_env();
     if (env) {
         if (self->rfield) {
@@ -46,6 +47,7 @@ static void pyjfield_dealloc(PyJFieldObject *self)
     Py_CLEAR(self->pyFieldName);
 
     PyObject_Del(self);
+    Py_DECREF(tp);
 #endif
 }
 

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -46,9 +46,17 @@ static void pyjfield_dealloc(PyJFieldObject *self)
 
     Py_CLEAR(self->pyFieldName);
 
-    PyObject_Del(self);
+    tp->tp_free((PyObject*) self);
     Py_DECREF(tp);
 #endif
+}
+
+
+static int pyjfield_traverse(PyJFieldObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->pyFieldName);
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 
@@ -58,7 +66,8 @@ PyJFieldObject* PyJField_New(JNIEnv *env, JepModuleState *modState,
     PyJFieldObject *pyf;
     jstring          jstr        = NULL;
 
-    pyf              = PyObject_NEW(PyJFieldObject, modState->PyJField_Type);
+    PyTypeObject* tp = modState->PyJField_Type;
+    pyf              = (PyJFieldObject*) tp->tp_alloc(tp, 0);
     pyf->rfield      = (*env)->NewGlobalRef(env, rfield);
     pyf->pyFieldName = NULL;
     pyf->fieldTypeId = -1;
@@ -645,6 +654,7 @@ static int pyjfield_descr_set(PyObject *field, PyObject *obj, PyObject *value)
 static PyType_Slot slots[] = {
     {Py_tp_doc, "jfield"},
     {Py_tp_dealloc, pyjfield_dealloc},
+    {Py_tp_traverse, pyjfield_traverse},
     {Py_tp_descr_set, pyjfield_descr_set},
     {Py_tp_descr_get, pyjfield_descr_get},
     {0, NULL},
@@ -653,6 +663,6 @@ static PyType_Slot slots[] = {
 PyType_Spec PyJField_Spec = {
     .name = "jep.PyJField",
     .basicsize = sizeof(PyJFieldObject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = slots
 };

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -50,16 +50,13 @@ static void pyjfield_dealloc(PyJFieldObject *self)
 }
 
 
-PyJFieldObject* PyJField_New(JNIEnv *env, jobject rfield)
+PyJFieldObject* PyJField_New(JNIEnv *env, JepModuleState *modState,
+                             jobject rfield)
 {
     PyJFieldObject *pyf;
     jstring          jstr        = NULL;
 
-    if (PyType_Ready(&PyJField_Type) < 0) {
-        return NULL;
-    }
-
-    pyf              = PyObject_NEW(PyJFieldObject, &PyJField_Type);
+    pyf              = PyObject_NEW(PyJFieldObject, modState->PyJField_Type);
     pyf->rfield      = (*env)->NewGlobalRef(env, rfield);
     pyf->pyFieldName = NULL;
     pyf->fieldTypeId = -1;
@@ -150,12 +147,9 @@ EXIT_ERROR:
 }
 
 
-int PyJField_Check(PyObject *obj)
+int PyJField_Check(JepModuleState* modState, PyObject *obj)
 {
-    if (PyObject_TypeCheck(obj, &PyJField_Type)) {
-        return 1;
-    }
-    return 0;
+    return PyObject_TypeCheck(obj, modState->PyJField_Type);
 }
 
 
@@ -646,45 +640,17 @@ static int pyjfield_descr_set(PyObject *field, PyObject *obj, PyObject *value)
     }
 }
 
+static PyType_Slot slots[] = {
+    {Py_tp_doc, "jfield"},
+    {Py_tp_dealloc, pyjfield_dealloc},
+    {Py_tp_descr_set, pyjfield_descr_set},
+    {Py_tp_descr_get, pyjfield_descr_get},
+    {0, NULL},
+};
 
-PyTypeObject PyJField_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJField",
-    sizeof(PyJFieldObject),
-    0,
-    (destructor) pyjfield_dealloc,            /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    "jfield",                                 /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    0,                                        /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    pyjfield_descr_get,                       /* tp_descr_get */
-    pyjfield_descr_set,                       /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+PyType_Spec PyJField_Spec = {
+    .name = "jep.PyJField",
+    .basicsize = sizeof(PyJFieldObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = slots
 };

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -36,6 +36,8 @@
 static void pyjfield_dealloc(PyJFieldObject *self)
 {
 #if USE_DEALLOC
+    PyObject_GC_UnTrack(self);
+    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env  = pyembed_get_env();
     if (env) {

--- a/src/main/c/Objects/pyjfield.c
+++ b/src/main/c/Objects/pyjfield.c
@@ -37,7 +37,6 @@ static void pyjfield_dealloc(PyJFieldObject *self)
 {
 #if USE_DEALLOC
     PyObject_GC_UnTrack(self);
-    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env  = pyembed_get_env();
     if (env) {

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -50,7 +50,8 @@ PyJMethodObject* PyJMethod_New(JNIEnv *env, JepModuleState *modState,
     pyname = jstring_As_PyString(env, jname);
     (*env)->DeleteLocalRef(env, jname);
 
-    pym                = PyObject_NEW(PyJMethodObject, modState->PyJMethod_Type);
+    PyTypeObject *tp   = modState->PyJMethod_Type;
+    pym                = (PyJMethodObject*) tp->tp_alloc(tp, 0);
     pym->rmethod       = (*env)->NewGlobalRef(env, rmethod);
     pym->parameters    = NULL;
     pym->lenParameters = -1;
@@ -162,9 +163,17 @@ static void pyjmethod_dealloc(PyJMethodObject *self)
 
     Py_CLEAR(self->pyMethodName);
 
-    PyObject_Del(self);
+    tp->tp_free((PyObject*) self);
     Py_DECREF(tp);
 #endif
+}
+
+
+static int pyjmethod_traverse(PyJMethodObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->pyMethodName);
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 
@@ -876,6 +885,7 @@ static PyMemberDef pyjmethod_members[] = {
 static PyType_Slot slots[] = {
     {Py_tp_doc, "jmethod"},
     {Py_tp_dealloc, pyjmethod_dealloc},
+    {Py_tp_traverse, pyjmethod_traverse},
     {Py_tp_call, pyjmethod_call},
     {Py_tp_members, pyjmethod_members},
     {Py_tp_descr_get, pyjmethod_descr_get},
@@ -885,6 +895,6 @@ static PyType_Slot slots[] = {
 PyType_Spec PyJMethod_Spec = {
     .name = "jep.PyJMethod",
     .basicsize = sizeof(PyJMethodObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
     .slots = slots
 };

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -149,6 +149,7 @@ EXIT_ERROR:
 static void pyjmethod_dealloc(PyJMethodObject *self)
 {
 #if USE_DEALLOC
+    PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env  = pyembed_get_env();
     if (env) {
         if (self->parameters) {
@@ -162,6 +163,7 @@ static void pyjmethod_dealloc(PyJMethodObject *self)
     Py_CLEAR(self->pyMethodName);
 
     PyObject_Del(self);
+    Py_DECREF(tp);
 #endif
 }
 

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -150,6 +150,7 @@ EXIT_ERROR:
 static void pyjmethod_dealloc(PyJMethodObject *self)
 {
 #if USE_DEALLOC
+    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env  = pyembed_get_env();
     if (env) {

--- a/src/main/c/Objects/pyjmethod.c
+++ b/src/main/c/Objects/pyjmethod.c
@@ -36,15 +36,12 @@
 
 // called internally to make new PyJMethodObject instances.
 // throws python exception and returns NULL on error.
-PyJMethodObject* PyJMethod_New(JNIEnv *env, jobject rmethod)
+PyJMethodObject* PyJMethod_New(JNIEnv *env, JepModuleState *modState,
+                               jobject rmethod)
 {
     jstring          jname  = NULL;
     PyObject        *pyname = NULL;
     PyJMethodObject *pym    = NULL;
-
-    if (PyType_Ready(&PyJMethod_Type) < 0) {
-        return NULL;
-    }
 
     jname = java_lang_reflect_Member_getName(env, rmethod);
     if (process_java_exception(env) || !jname) {
@@ -53,7 +50,7 @@ PyJMethodObject* PyJMethod_New(JNIEnv *env, jobject rmethod)
     pyname = jstring_As_PyString(env, jname);
     (*env)->DeleteLocalRef(env, jname);
 
-    pym                = PyObject_NEW(PyJMethodObject, &PyJMethod_Type);
+    pym                = PyObject_NEW(PyJMethodObject, modState->PyJMethod_Type);
     pym->rmethod       = (*env)->NewGlobalRef(env, rmethod);
     pym->parameters    = NULL;
     pym->lenParameters = -1;
@@ -169,9 +166,9 @@ static void pyjmethod_dealloc(PyJMethodObject *self)
 }
 
 
-int PyJMethod_Check(PyObject *obj)
+int PyJMethod_Check(JepModuleState *modState, PyObject *obj)
 {
-    return PyObject_TypeCheck(obj, &PyJMethod_Type);
+    return PyObject_TypeCheck(obj, modState->PyJMethod_Type);
 }
 
 int PyJMethod_GetParameterCount(PyJMethodObject *method, JNIEnv *env)
@@ -874,45 +871,18 @@ static PyMemberDef pyjmethod_members[] = {
     {NULL}  /* Sentinel */
 };
 
+static PyType_Slot slots[] = {
+    {Py_tp_doc, "jmethod"},
+    {Py_tp_dealloc, pyjmethod_dealloc},
+    {Py_tp_call, pyjmethod_call},
+    {Py_tp_members, pyjmethod_members},
+    {Py_tp_descr_get, pyjmethod_descr_get},
+    {0, NULL},
+};
 
-PyTypeObject PyJMethod_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJMethod",
-    sizeof(PyJMethodObject),
-    0,
-    (destructor) pyjmethod_dealloc,           /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    (ternaryfunc) pyjmethod_call,             /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    "jmethod",                                /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    0,                                        /* tp_methods */
-    pyjmethod_members,                        /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    pyjmethod_descr_get,                      /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+PyType_Spec PyJMethod_Spec = {
+    .name = "jep.PyJMethod",
+    .basicsize = sizeof(PyJMethodObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = slots
 };

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -98,6 +98,7 @@ static PyObject* pyjmonitor_exit(PyObject* self, PyObject* args)
 void pyjmonitor_dealloc(PyJMonitorObject *self)
 {
 #if USE_DEALLOC
+    PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env = pyembed_get_env();
     if (env) {
         if (self->lock) {
@@ -106,6 +107,7 @@ void pyjmonitor_dealloc(PyJMonitorObject *self)
     }
 
     PyObject_Del(self);
+    Py_DECREF(tp);
 #endif
 }
 

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -99,6 +99,7 @@ static PyObject* pyjmonitor_exit(PyObject* self, PyObject* args)
 void pyjmonitor_dealloc(PyJMonitorObject *self)
 {
 #if USE_DEALLOC
+    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env = pyembed_get_env();
     if (env) {

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -38,7 +38,8 @@ PyObject* PyJMonitor_New(jobject obj)
         return NULL;
     }
 
-    monitor = PyObject_NEW(PyJMonitorObject, modState->PyJMonitor_Type);
+    PyTypeObject* tp = modState->PyJMonitor_Type;
+    monitor = (PyJMonitorObject*) tp->tp_alloc(tp, 0);
     monitor->lock = (*env)->NewGlobalRef(env, obj);
     if (process_java_exception(env)) {
         return NULL;
@@ -106,9 +107,16 @@ void pyjmonitor_dealloc(PyJMonitorObject *self)
         }
     }
 
-    PyObject_Del(self);
+    tp->tp_free((PyObject*) self);
     Py_DECREF(tp);
 #endif
+}
+
+
+static int pyjmonitor_traverse(PyJMonitorObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 
@@ -133,6 +141,7 @@ static PyMethodDef pyjmonitor_methods[] = {
 static PyType_Slot slots[] = {
     {Py_tp_doc, "jmonitor"},
     {Py_tp_dealloc, pyjmonitor_dealloc},
+    {Py_tp_traverse, pyjmonitor_traverse},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_methods, pyjmonitor_methods},
     {0, NULL},
@@ -141,6 +150,6 @@ static PyType_Slot slots[] = {
 PyType_Spec PyJMonitor_Spec = {
     .name = "jep.PyJMonitor",
     .basicsize = sizeof(PyJMonitorObject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = slots
 };

--- a/src/main/c/Objects/pyjmonitor.c
+++ b/src/main/c/Objects/pyjmonitor.c
@@ -33,26 +33,17 @@ PyObject* PyJMonitor_New(jobject obj)
     PyJMonitorObject *monitor = NULL;
     JNIEnv           *env     = pyembed_get_env();
 
-    if (PyType_Ready(&PyJMonitor_Type) < 0) {
+    JepModuleState* modState = pyembed_get_module_state();
+    if (!modState) {
         return NULL;
     }
 
-    monitor = PyObject_NEW(PyJMonitorObject,
-                           &PyJMonitor_Type);
+    monitor = PyObject_NEW(PyJMonitorObject, modState->PyJMonitor_Type);
     monitor->lock = (*env)->NewGlobalRef(env, obj);
     if (process_java_exception(env)) {
         return NULL;
     }
     return (PyObject*) monitor;
-}
-
-
-int PyJMonitor_Check(PyObject *obj)
-{
-    if (PyObject_TypeCheck(obj, &PyJMonitor_Type)) {
-        return 1;
-    }
-    return 0;
 }
 
 
@@ -137,48 +128,17 @@ static PyMethodDef pyjmonitor_methods[] = {
     { NULL, NULL }
 };
 
+static PyType_Slot slots[] = {
+    {Py_tp_doc, "jmonitor"},
+    {Py_tp_dealloc, pyjmonitor_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_methods, pyjmonitor_methods},
+    {0, NULL},
+};
 
-/*
- * Inherits from PyJObject_Type
- */
-PyTypeObject PyJMonitor_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJMonitor",
-    sizeof(PyJMonitorObject),
-    0,
-    (destructor) pyjmonitor_dealloc,          /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    PyObject_GenericGetAttr,                  /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    "jmonitor",                               /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    pyjmonitor_methods,                       /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+PyType_Spec PyJMonitor_Spec = {
+    .name = "jep.PyJMonitor",
+    .basicsize = sizeof(PyJMonitorObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = slots
 };

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -38,8 +38,8 @@ PyObject* PyJMultiMethod_New(JepModuleState* modState, PyObject* method1,
         PyErr_SetString(PyExc_TypeError, "PyJMultiMethod can only hold PyJMethods");
         return NULL;
     }
-
-    mm = PyObject_NEW(PyJMultiMethodObject, modState->PyJMultiMethod_Type);
+    PyTypeObject *tp = modState->PyJMultiMethod_Type;
+    mm = (PyJMultiMethodObject*) tp->tp_alloc(tp, 0);
     if (mm == NULL) {
         return NULL;
     }
@@ -176,8 +176,15 @@ static void pyjmultimethod_dealloc(PyJMultiMethodObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     Py_CLEAR(self->methodList);
-    PyObject_Del(self);
+    tp->tp_free((PyObject*) self);
     Py_DECREF(tp);
+}
+
+static int pyjmultimethod_traverse(PyJMultiMethodObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->methodList);
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 static PyObject* pyjmultimethod_descr_get(PyObject *func, PyObject *obj,
@@ -203,6 +210,7 @@ name as a single callable python object.");
 static PyType_Slot slots[] = {
     {Py_tp_doc, (void*) pyjmultimethod_doc},
     {Py_tp_dealloc, pyjmultimethod_dealloc},
+    {Py_tp_traverse, pyjmultimethod_traverse},
     {Py_tp_call, pyjmultimethod_call},
     {Py_tp_getset, pyjmultimethod_getsetlist},
     {Py_tp_descr_get, pyjmultimethod_descr_get},
@@ -212,6 +220,6 @@ static PyType_Slot slots[] = {
 PyType_Spec PyJMultiMethod_Spec = {
     .name = "jep.PyJMultiMethod",
     .basicsize = sizeof(PyJMultiMethodObject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = slots
 };

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -174,6 +174,7 @@ static PyObject* pyjmultimethod_getmethods(PyObject* multimethod)
 
 static void pyjmultimethod_dealloc(PyJMultiMethodObject *self)
 {
+    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     Py_CLEAR(self->methodList);
     tp->tp_free((PyObject*) self);

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -28,19 +28,18 @@
 #include "Jep.h"
 
 
-PyObject* PyJMultiMethod_New(PyObject* method1, PyObject* method2)
+PyObject* PyJMultiMethod_New(JepModuleState* modState, PyObject* method1,
+                             PyObject* method2)
 {
     PyJMultiMethodObject* mm = NULL;
 
-    if (PyType_Ready(&PyJMultiMethod_Type) < 0) {
-        return NULL;
-    }
-    if (!PyJMethod_Check(method1) || !PyJMethod_Check(method2)) {
+    if (!PyJMethod_Check(modState, method1)
+            || !PyJMethod_Check(modState, method2)) {
         PyErr_SetString(PyExc_TypeError, "PyJMultiMethod can only hold PyJMethods");
         return NULL;
     }
 
-    mm = PyObject_NEW(PyJMultiMethodObject, &PyJMultiMethod_Type);
+    mm = PyObject_NEW(PyJMultiMethodObject, modState->PyJMultiMethod_Type);
     if (mm == NULL) {
         return NULL;
     }
@@ -56,15 +55,16 @@ PyObject* PyJMultiMethod_New(PyObject* method1, PyObject* method2)
     return (PyObject *) mm;
 }
 
-int PyJMultiMethod_Append(PyObject* multimethod, PyObject* method)
+int PyJMultiMethod_Append(JepModuleState* modState, PyObject* multimethod,
+                          PyObject* method)
 {
     PyJMultiMethodObject* mm = NULL;
-    if (!PyJMultiMethod_Check(multimethod)) {
+    if (!PyJMultiMethod_Check(modState, multimethod)) {
         PyErr_SetString(PyExc_TypeError,
                         "PyJMultiMethod_Append received incorrect type");
         return -1;
     }
-    if (!PyJMethod_Check(method)) {
+    if (!PyJMethod_Check(modState, method)) {
         PyErr_SetString(PyExc_TypeError, "PyJMultiMethod can only hold PyJMethods");
         return -1;
     }
@@ -72,9 +72,9 @@ int PyJMultiMethod_Append(PyObject* multimethod, PyObject* method)
     return PyList_Append(mm->methodList, method);
 }
 
-int PyJMultiMethod_Check(PyObject* object)
+int PyJMultiMethod_Check(JepModuleState* modState, PyObject* object)
 {
-    return PyObject_TypeCheck(object, &PyJMultiMethod_Type);
+    return PyObject_TypeCheck(object, modState->PyJMultiMethod_Type);
 }
 
 PyObject* PyJMultiMethod_GetName(PyObject* multimethod)
@@ -82,11 +82,6 @@ PyObject* PyJMultiMethod_GetName(PyObject* multimethod)
     PyJMultiMethodObject* mm         = NULL;
     PyJMethodObject*     method     = NULL;
     PyObject*             methodName = NULL;
-    if (!PyJMultiMethod_Check(multimethod)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "PyJMultiMethod_GetName received incorrect type");
-        return NULL;
-    }
     mm = (PyJMultiMethodObject*) multimethod;
     method = (PyJMethodObject*) PyList_GetItem(mm->methodList, 0);
     methodName = method->pyMethodName;
@@ -99,7 +94,6 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
                                      PyObject *keywords)
 {
     PyJMultiMethodObject* mm         = NULL;
-    PyObject* methodName             = NULL;
     /*
      * cand is a candidate method that passes the simple compatiblity check but
      * the complex check may not have been run.
@@ -116,14 +110,7 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
     Py_ssize_t        argsSize       = 0;
     JNIEnv*           env            = NULL;
 
-    if (!PyJMultiMethod_Check(multimethod)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "pyjmultimethod_call_internal received incorrect type");
-        return NULL;
-    }
-
     mm = (PyJMultiMethodObject*) multimethod;
-    methodName = PyJMultiMethod_GetName(multimethod);
     methodCount = PyList_Size(mm->methodList);
     argsSize = PyTuple_Size(args) - 1;
     env = pyembed_get_env();
@@ -133,10 +120,10 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
                                   methodPosition);
         int parameterCount = PyJMethod_GetParameterCount(method, env);
         if (keywords && PyDict_Size(keywords) > 0 && !method->isKwArgs) {
-            /* 
-	     * keywords were passed in but this method does not support
-	     * keywords so keep looking at other methods.
-	     */
+            /*
+             * keywords were passed in but this method does not support
+             * keywords so keep looking at other methods.
+             */
             continue;
         } else if (method->isKwArgs) {
             parameterCount -= 1;
@@ -168,8 +155,6 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
         }
     }
 
-    Py_DECREF(methodName);
-
     if (cand) {
         return PyObject_Call((PyObject*) cand, args, keywords);
     } else {
@@ -183,13 +168,7 @@ static PyObject* pyjmultimethod_call(PyObject *multimethod,
 /* returns internal list as tuple since its not safe to modify the list*/
 static PyObject* pyjmultimethod_getmethods(PyObject* multimethod)
 {
-    PyJMultiMethodObject* mm         = NULL;
-    if (!PyJMultiMethod_Check(multimethod)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "PyJMultiMethod_GetName received incorrect type");
-        return NULL;
-    }
-    mm = (PyJMultiMethodObject*) multimethod;
+    PyJMultiMethodObject* mm = (PyJMultiMethodObject*) multimethod;
     return PyList_AsTuple(mm->methodList);
 }
 
@@ -219,44 +198,18 @@ PyDoc_STRVAR(pyjmultimethod_doc,
              "PyJMultiMethod wraps multiple java methods from the same class with the same\n\
 name as a single callable python object.");
 
-PyTypeObject PyJMultiMethod_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "jep.PyJMultiMethod",
-    sizeof(PyJMultiMethodObject),
-    0,
-    (destructor) pyjmultimethod_dealloc,      /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash  */
-    (ternaryfunc) pyjmultimethod_call,        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT |
-    Py_TPFLAGS_IMMUTABLETYPE,                 /* tp_flags */
-    pyjmultimethod_doc,                       /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    0,                                        /* tp_methods */
-    0,                                        /* tp_members */
-    pyjmultimethod_getsetlist,                /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    pyjmultimethod_descr_get,                 /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    NULL,                                     /* tp_new */
+static PyType_Slot slots[] = {
+    {Py_tp_doc, (void*) pyjmultimethod_doc},
+    {Py_tp_dealloc, pyjmultimethod_dealloc},
+    {Py_tp_call, pyjmultimethod_call},
+    {Py_tp_getset, pyjmultimethod_getsetlist},
+    {Py_tp_descr_get, pyjmultimethod_descr_get},
+    {0, NULL},
+};
+
+PyType_Spec PyJMultiMethod_Spec = {
+    .name = "jep.PyJMultiMethod",
+    .basicsize = sizeof(PyJMultiMethodObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = slots
 };

--- a/src/main/c/Objects/pyjmultimethod.c
+++ b/src/main/c/Objects/pyjmultimethod.c
@@ -174,8 +174,10 @@ static PyObject* pyjmultimethod_getmethods(PyObject* multimethod)
 
 static void pyjmultimethod_dealloc(PyJMultiMethodObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
     Py_CLEAR(self->methodList);
     PyObject_Del(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* pyjmultimethod_descr_get(PyObject *func, PyObject *obj,

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -68,6 +68,7 @@ PyObject* PyJObject_New(JNIEnv *env, PyTypeObject* type, jobject obj,
 static void pyjobject_dealloc(PyJObject *self)
 {
 #if USE_DEALLOC
+    PyObject_GC_UnTrack(self);
     PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env = pyembed_get_env();
     if (env) {

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -45,7 +45,7 @@ int PyJObject_Check(PyObject *pyobj)
 PyObject* PyJObject_New(JNIEnv *env, PyTypeObject* type, jobject obj,
                         jclass class)
 {
-    PyJObject *pyjob = (PyJObject*) PyType_GenericAlloc(type, 0);
+    PyJObject *pyjob = (PyJObject*) type->tp_alloc(type, 0);
 
     if (obj) {
         pyjob->object = (*env)->NewGlobalRef(env, obj);
@@ -81,6 +81,12 @@ static void pyjobject_dealloc(PyJObject *self)
     tp->tp_free((PyObject*) self);
     Py_DECREF(tp);
 #endif
+}
+
+static int pyjobject_traverse(PyJObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(self));
+    return 0;
 }
 
 // call toString() on jobject. returns null on error.
@@ -299,6 +305,7 @@ static PyGetSetDef pyjobject_getset[] = {
 static PyType_Slot slots[] = {
     {Py_tp_doc, "Jep java.lang.Object"},
     {Py_tp_dealloc, pyjobject_dealloc},
+    {Py_tp_traverse, pyjobject_traverse},
     {Py_tp_hash, pyjobject_hash},
     {Py_tp_str, pyjobject_str},
     {Py_tp_richcompare, pyjobject_richcompare},
@@ -310,6 +317,6 @@ static PyType_Slot slots[] = {
 PyType_Spec PyJObject_Spec = {
     .name = "java.lang.Object",
     .basicsize = sizeof(PyJObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
     .slots = slots
 };

--- a/src/main/c/Objects/pyjobject.c
+++ b/src/main/c/Objects/pyjobject.c
@@ -68,6 +68,7 @@ PyObject* PyJObject_New(JNIEnv *env, PyTypeObject* type, jobject obj,
 static void pyjobject_dealloc(PyJObject *self)
 {
 #if USE_DEALLOC
+    PyTypeObject *tp = Py_TYPE(self);
     JNIEnv *env = pyembed_get_env();
     if (env) {
         if (self->object) {
@@ -77,8 +78,8 @@ static void pyjobject_dealloc(PyJObject *self)
             (*env)->DeleteGlobalRef(env, self->clazz);
         }
     }
-
-    Py_TYPE((PyObject*) self)->tp_free((PyObject*) self);
+    tp->tp_free((PyObject*) self);
+    Py_DECREF(tp);
 #endif
 }
 

--- a/src/test/java/jep/test/TestIsolatedSubInterpreter.java
+++ b/src/test/java/jep/test/TestIsolatedSubInterpreter.java
@@ -25,7 +25,8 @@ public class TestIsolatedSubInterpreter {
             .withInitial(() -> new SubInterpreter(JEP_CONFIG));
 
     public static void main(String... args) {
-        try (ExecutorService executor = Executors.newFixedThreadPool(12)) {
+        ExecutorService executor = Executors.newFixedThreadPool(12);
+        try {
             List<CompletableFuture<?>> futures = new ArrayList<>();
             for (int i = 0; i < 1000; i++) {
                 futures.add(CompletableFuture.supplyAsync(() -> {
@@ -34,6 +35,8 @@ public class TestIsolatedSubInterpreter {
             }
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                     .join();
+        } finally {
+            executor.shutdown();
         }
 
     }

--- a/src/test/java/jep/test/TestIsolatedSubInterpreter.java
+++ b/src/test/java/jep/test/TestIsolatedSubInterpreter.java
@@ -1,0 +1,41 @@
+package jep.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import jep.Interpreter;
+import jep.JepConfig;
+import jep.SubInterpreter;
+import jep.SubInterpreterOptions;
+
+/**
+ * This test case runs some simple Python in many threads using isolated
+ * sub-interpreters to ensure that there aren't any concurrency issues that
+ * cause it to crash.
+ */
+public class TestIsolatedSubInterpreter {
+
+    private static final JepConfig JEP_CONFIG = new JepConfig()
+            .setSubInterpreterOptions(SubInterpreterOptions.isolated());
+
+    private static final ThreadLocal<Interpreter> subInterpreter = ThreadLocal
+            .withInitial(() -> new SubInterpreter(JEP_CONFIG));
+
+    public static void main(String... args) {
+        try (ExecutorService executor = Executors.newFixedThreadPool(12)) {
+            List<CompletableFuture<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                futures.add(CompletableFuture.supplyAsync(() -> {
+                    return subInterpreter.get().getValue("1 + 2");
+                }, executor));
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .join();
+        }
+
+    }
+
+}

--- a/src/test/python/test_regressions.py
+++ b/src/test/python/test_regressions.py
@@ -49,3 +49,6 @@ class TestRegressions(unittest.TestCase):
             thread.join();
         from java.lang import Object
         self.assertEqual(3, len(Object.wait.__methods__))
+        
+    def test_isolated_subinterpreter(self):
+        jep_pipe(build_java_process_cmd('jep.test.TestIsolatedSubInterpreter'))


### PR DESCRIPTION
The primary goal of this change is to fix the crashes described in #599 when isolated sub-interpreters are used. The crashes are mostly a problem in the case where all interpreters are initialized on different threads at the same time.

I was not able to track down the exact source of crashes in the cpython code but it seems to be related to the internal type cache. I found that the crashes would not occur if I stopped using all our static types which also required removing a bunch of jep functionality. Since heap types are specific to an interpreter they are safer for isolated interpreters so I started testing using more heap types instead of removing functionality. Using heap types stopped the crashing. This change converts all of the jep types that were previously static types to be heap types instead. I have not proven definitively that all the types were involved in the crashes but a majority are so it seemed beneficial to do all of them for consistency.

The biggest downside to heap types is the type object can no longer be referenced directly in c. I extended the approach from #594 to store the type definitions in the module state. In the code that creates new PyJTypes there is a need to create many super types, methods, and fields and that needs a reference to the module state. To avoid redundant lookups of the module state when making new PyJTypes the module state is passed around between most of the pyjtype functions.

Another benefit of using heap types is that PyTypeObject used by static types is not part of the cpython Limited ABI but the functions for initializing the types are. This change brings us a little closer to being able to use the stable ABI to distribute a single python binary for multiple versions of cpython.