### PR TITLE
Enable calling jep.findClass() from threads created by python.

### DIFF
--- a/src/main/c/Jep/pyembed.c
+++ b/src/main/c/Jep/pyembed.c
@@ -1042,21 +1042,12 @@ static PyObject* pyembed_findclass(PyObject *self, PyObject *args)
     PyObject  *result    = NULL;
     char      *name, *p;
     jclass     clazz;
-    JepThread *jepThread;
 
     if (!PyArg_ParseTuple(args, "s", &name)) {
         return NULL;
     }
 
-    jepThread = pyembed_get_jepthread();
-    if (!jepThread) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_RuntimeError, "Invalid JepThread pointer.");
-        }
-        return NULL;
-    }
-
-    env = jepThread->env;
+    env = pyembed_get_env();
 
     // replace '.' with '/'
     // i'm told this is okay to do with unicode.


### PR DESCRIPTION
This just switched fep.findClass() to use pyembed_get_env() instead of pyembed_get_jepthread() for accessing the JNIEnv*. pyembed_get_env() is already used in 68 places(pyembed_get_jepthread() is in 5) so it has proven a reliable way to access the JNIEnv* but pyembed_get_env() will work on any thread where as pyembed_get_jepthread() works only on threads with a jep instance in java.

In the longer term I would like to enable jep to be used from python created threads to give users the ability to take advantage of multithreading in python. Using jep in python created threads also gets us closer to being able to use jep to embed java in a python application. I do not have time to make much progress on that goal for the 4.3 release but this is a simple change that is a very small step in that direction.