### PR TITLE
Make numpy required to build.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include LICENSE
 include AUTHORS
 include README.rst
 include pom.xml
+include pyproject.toml

--- a/README.rst
+++ b/README.rst
@@ -39,12 +39,10 @@ Some benefits of embedding CPython in a JVM:
 
 Installation
 ------------
-Simply run ``pip install --no-cache-dir --no-build-isolation jep`` or download
-the source and run ``pip install .``. Building and installing require the JDK,
-Python, setuptools, and optionally numpy to be installed beforehand. The 
-``--no-cache-dir`` and ``--no-build-isolation`` options are not strictly
-required, however those settings enable Jep to make customizations for your
-environment such as enabling numpy specific behavior if numpy is installed.
+Simply run ``pip install jep`` or download the source and run
+``pip install .``. Building and installing require the JDK and Python,
+to be installed beforehand. Pip will need to be able to install setuptools
+and numpy to build jep.
 
 Dependencies
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = [
+  "setuptools >= 61.0",
+  "numpy >= 1.7" # Remove numpy to build without numpy support.
+]
 build-backend = "setuptools.build_meta:__legacy__"
 
 [project]

--- a/release_notes/4.3-notes.rst
+++ b/release_notes/4.3-notes.rst
@@ -25,8 +25,8 @@ Modernized build
 ****************
 Project configuration is now in pyproject.toml. The actual build is still
 done with the legacy setuptools. For compatibility with the isolated build
-environment used by pip numpy is now a required build dependency. When jep is
-built with numpt it can be used without numpy as long as NDArrays are not
+environment used by pip, numpy is now a required build dependency. When jep is
+built with numpy it can be used without numpy as long as NDArrays are not
 passed from Java to Python. It is still possible to build jep without numpy
 if neccesary but it now requires downloading the source and modifying
 pyproject.toml to remove the numpy dependency.

--- a/release_notes/4.3-notes.rst
+++ b/release_notes/4.3-notes.rst
@@ -1,6 +1,8 @@
 Jep 4.3 Release Notes
 *********************
-This release drops support for versions of Python older than 3.10.
+This release drops support for versions of Python older than 3.10. It includes
+changes to modernize and simplify the build, improve compatibility with
+isolated sub-interpreters, and remove use of deprecated Python features.
 
 Updates to PyConfig
 *******************
@@ -18,3 +20,13 @@ It is now possible to attach multiple threads to an existing Interpreter using
 Interpreters created this way will share state such as ``sys.modules`` and
 even have the option to share globals which allows multiple threads to have
 identical access to an interpreter.
+
+Modernized build
+****************
+Project configuration is now in pyproject.toml. The actual build is still
+done with the legacy setuptools. For compatibility with the isolated build
+environment used by pip numpy is now a required build dependency. When jep is
+built with numpt it can be used without numpy as long as NDArrays are not
+passed from Java to Python. It is still possible to build jep without numpy
+if neccesary but it now requires downloading the source and modifying
+pyproject.toml to remove the numpy dependency.


### PR DESCRIPTION
This change removes the requirement to disable build isolation when installing jep with numpy support. 