### PR TITLE
Use PyJObject ClassLoader instead of jep.forName in java import hook.

### DIFF
--- a/src/main/java/jep/Jep.java
+++ b/src/main/java/jep/Jep.java
@@ -238,10 +238,12 @@ public abstract class Jep implements Interpreter {
         if (enquirer == null) {
             enquirer = ClassList.getInstance();
         }
+        set("classLoader", this.classLoader);
         set("classlist", enquirer);
         exec("from jep import java_import_hook");
-        exec("java_import_hook.setupImporter(classlist)");
+        exec("java_import_hook.setupImporter(classLoader, classlist)");
         exec("del classlist");
+        exec("del classLoader");
         exec("del java_import_hook");
     }
 

--- a/src/test/python/test_import.py
+++ b/src/test/python/test_import.py
@@ -1,5 +1,6 @@
 import unittest
 from jep import JepJavaImporter, findClass
+from java.lang import Thread
 
 
 Jep = findClass('jep.Jep')
@@ -15,7 +16,7 @@ class TestImport(unittest.TestCase):
         from java.sql import DriverManager
 
     def test_not_found(self):
-        importer = JepJavaImporter()
+        importer = JepJavaImporter(Thread.currentThread().getContextClassLoader())
         spec = importer.find_spec('java.lang', None)
         mod = importer.create_module(spec)
         mod.Integer


### PR DESCRIPTION
This is part of my efforts to make jep more functional from java created threads. This adds a class loader to the java import hook. Since `jep.forName()` is calling `ClassLoader.loadClass()` internally using the same class loader that is used to construct the interpreter instance this change should not be changing any actual behavior of the java import hook. However since the class loader in the jep thread state is not available on python created threads and the class loader in the hook is available on those threads this will allow the hook to work on python created threads.