### PR TITLE
Fix subpackage access through attributes in Java imports.

### DIFF
--- a/src/main/python/jep/java_import_hook.py
+++ b/src/main/python/jep/java_import_hook.py
@@ -47,6 +47,7 @@ class module(ModuleType):
             if subpkgs and name in subpkgs:
                 fullname = self.__name__ + '.' + name
                 mod = makeModule(fullname, self.__loader__,
+                                 self.__classLoader__,
                                  self.__classEnquirer__)
                 return mod
             elif name == '__all__':

--- a/src/test/python/test_import.py
+++ b/src/test/python/test_import.py
@@ -40,6 +40,12 @@ class TestImport(unittest.TestCase):
         from java.lang import System
         System.out.print('')  # should still work
 
+    def test_subpaclage_access(sekf):
+        # Check that a subpackage is available through attribute access
+        # use a subpacakge that isn't commonly used from Python to avoid caching
+        import java
+        Charset = java.nio.charset.Charset
+
     def test_conflicting_package(self):
         from io import DEFAULT_BUFFER_SIZE
 


### PR DESCRIPTION
This is the fix for #620. In Jep 4.3.0 I accidentally broke the ability to access Java sub-packages as attributes from java imports because I did not pass along the ClassLoader. This corrects that omission.