### PR TITLE
Add missing JNI frame pop when checking for functional interfaces.

### DIFF
--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -632,6 +632,7 @@ char isFunctionalInterfaceType(JNIEnv *env, jclass type)
         return 0;
     }
     if (!isInterface) {
+        (*env)->PopLocalFrame(env, NULL);
         return 0; // It's not an interface, so it can't be functional
     }
     methods = java_lang_Class_getMethods(env, type);


### PR DESCRIPTION
This fixes a memory leak when a Python callable object is converted to a Java object. The native code that is checking for functional interfaces was not popping the local JNI frame in an early return, which caused the frame to leak memory.

This problem was identified in #618