### PR TITLE
Guard NULL from GetStringUTFChars in raiseTypeError

### DIFF
--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -56,6 +56,14 @@ static void raiseTypeError(JNIEnv *env, PyObject *pyobject, jclass expectedType)
         return;
     }
     expTypeName = (*env)->GetStringUTFChars(env, expTypeJavaName, 0);
+    if (expTypeName == NULL) {
+        /*
+         * GetStringUTFChars can fail and leave a pending JNI exception (such as
+         * OutOfMemoryError). Clear it so it does not interfere with later JNI
+         * calls; the type error is still reported with a fallback name below.
+         */
+        (*env)->ExceptionClear(env);
+    }
     if (PyJClass_Check(pyobject)) {
         actTypeName = "java.lang.Class";
     } else {

--- a/src/main/c/Jep/convert_p2j.c
+++ b/src/main/c/Jep/convert_p2j.c
@@ -61,9 +61,11 @@ static void raiseTypeError(JNIEnv *env, PyObject *pyobject, jclass expectedType)
     } else {
         actTypeName = pyobject->ob_type->tp_name;
     }
-    PyErr_Format(PyExc_TypeError, "Expected %s but received a %s.", expTypeName,
-                 actTypeName);
-    (*env)->ReleaseStringUTFChars(env, expTypeJavaName, expTypeName);
+    PyErr_Format(PyExc_TypeError, "Expected %s but received a %s.",
+                 expTypeName ? expTypeName : "<unknown>", actTypeName);
+    if (expTypeName != NULL) {
+        (*env)->ReleaseStringUTFChars(env, expTypeJavaName, expTypeName);
+    }
     (*env)->DeleteLocalRef(env, expTypeJavaName);
 }
 


### PR DESCRIPTION
Fixes #643. In `raiseTypeError`, the return value of `GetStringUTFChars` was passed straight to `PyErr_Format` as a `%s` argument. Per the JNI spec that call returns NULL if it can't allocate the native string, and formatting NULL with `%s` crashes. This falls back to "<unknown>" for the message and skips the matching `ReleaseStringUTFChars` when nothing was returned, so the type-error path stays intact on that rare allocation failure.